### PR TITLE
feat: Add Summary and Recommendation tabs

### DIFF
--- a/src/components/module/recommendation-section.tsx
+++ b/src/components/module/recommendation-section.tsx
@@ -1,0 +1,216 @@
+import React, { useState, useRef } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Play, Pause } from "lucide-react";
+
+interface ActionItem {
+  index: number;
+  title: string;
+  description: string;
+  priority: "high" | "medium" | "low";
+  timeline?: string;
+}
+
+interface NextStep {
+  index: number;
+  step: string;
+  owner?: string;
+  dueDate?: string;
+}
+
+interface RecommendationSectionProps {
+  title?: string;
+  description?: string;
+  recommendationText: string;
+  actionItems: ActionItem[];
+  nextSteps: NextStep[];
+  onGenerateAudio?: () => Promise<string>;
+}
+
+const getPriorityColor = (priority: "high" | "medium" | "low") => {
+  switch (priority) {
+    case "high":
+      return "bg-red-100 text-red-800";
+    case "medium":
+      return "bg-yellow-100 text-yellow-800";
+    case "low":
+      return "bg-green-100 text-green-800";
+    default:
+      return "bg-gray-100 text-gray-800";
+  }
+};
+
+export function RecommendationSection({
+  title = "Recommendations",
+  description = "Strategic recommendations and action items",
+  recommendationText,
+  actionItems,
+  nextSteps,
+  onGenerateAudio,
+}: RecommendationSectionProps) {
+  const [isPlayingAudio, setIsPlayingAudio] = useState(false);
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  const handlePlayAudio = async () => {
+    try {
+      if (!audioUrl && onGenerateAudio) {
+        const url = await onGenerateAudio();
+        setAudioUrl(url);
+        setTimeout(() => {
+          if (audioRef.current) {
+            audioRef.current.play();
+            setIsPlayingAudio(true);
+          }
+        }, 100);
+      } else if (audioRef.current) {
+        if (isPlayingAudio) {
+          audioRef.current.pause();
+          setIsPlayingAudio(false);
+        } else {
+          audioRef.current.play();
+          setIsPlayingAudio(true);
+        }
+      }
+    } catch (error) {
+      console.error("Error playing audio:", error);
+    }
+  };
+
+  const handleAudioEnded = () => {
+    setIsPlayingAudio(false);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Recommendation Note Card */}
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between">
+          <div className="flex-1">
+            <CardTitle>{title}</CardTitle>
+            <p className="text-sm text-gray-600 mt-1">{description}</p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handlePlayAudio}
+            className="flex items-center gap-2 ml-4"
+          >
+            {isPlayingAudio ? (
+              <>
+                <Pause className="h-4 w-4" />
+                Pause
+              </>
+            ) : (
+              <>
+                <Play className="h-4 w-4" />
+                Play Audio
+              </>
+            )}
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
+            <p className="text-gray-700 leading-relaxed whitespace-pre-wrap">
+              {recommendationText}
+            </p>
+          </div>
+          <audio
+            ref={audioRef}
+            src={audioUrl || ""}
+            onEnded={handleAudioEnded}
+            className="hidden"
+          />
+        </CardContent>
+      </Card>
+
+      {/* Action Items */}
+      {actionItems.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Action Items</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {actionItems.map((item, idx) => (
+                <div
+                  key={idx}
+                  className="border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow"
+                >
+                  <div className="flex items-start justify-between gap-4 mb-2">
+                    <div className="flex items-center gap-3 flex-1">
+                      <div className="flex-shrink-0">
+                        <span className="inline-flex items-center justify-center h-8 w-8 rounded-full bg-blue-100 text-blue-600 font-semibold text-sm">
+                          {item.index}
+                        </span>
+                      </div>
+                      <div className="flex-1">
+                        <h4 className="font-semibold text-gray-900">
+                          {item.title}
+                        </h4>
+                      </div>
+                    </div>
+                    <Badge className={getPriorityColor(item.priority)}>
+                      {item.priority.charAt(0).toUpperCase() + item.priority.slice(1)} Priority
+                    </Badge>
+                  </div>
+                  <p className="text-gray-600 text-sm ml-11 mb-2">
+                    {item.description}
+                  </p>
+                  {item.timeline && (
+                    <div className="ml-11 text-xs text-gray-500">
+                      Timeline: <span className="font-medium">{item.timeline}</span>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Next Steps */}
+      {nextSteps.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Next Steps</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {nextSteps.map((step, idx) => (
+                <div
+                  key={idx}
+                  className="flex gap-4 pb-4 border-b border-gray-100 last:pb-0 last:border-0"
+                >
+                  <div className="flex-shrink-0">
+                    <div className="flex items-center justify-center h-8 w-8 rounded-full bg-green-100 text-green-600 font-semibold text-sm">
+                      {step.index}
+                    </div>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium text-gray-900 mb-1">{step.step}</p>
+                    <div className="flex flex-wrap gap-3 text-xs text-gray-600">
+                      {step.owner && (
+                        <span className="flex items-center">
+                          <span className="font-medium">Owner:</span>
+                          <span className="ml-1">{step.owner}</span>
+                        </span>
+                      )}
+                      {step.dueDate && (
+                        <span className="flex items-center">
+                          <span className="font-medium">Due:</span>
+                          <span className="ml-1">{step.dueDate}</span>
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/module/recommendation-section.tsx
+++ b/src/components/module/recommendation-section.tsx
@@ -152,7 +152,9 @@ export function RecommendationSection({
                       </div>
                     </div>
                     <Badge className={getPriorityColor(item.priority)}>
-                      {item.priority.charAt(0).toUpperCase() + item.priority.slice(1)} Priority
+                      {item.priority.charAt(0).toUpperCase() +
+                        item.priority.slice(1)}{" "}
+                      Priority
                     </Badge>
                   </div>
                   <p className="text-gray-600 text-sm ml-11 mb-2">
@@ -160,7 +162,8 @@ export function RecommendationSection({
                   </p>
                   {item.timeline && (
                     <div className="ml-11 text-xs text-gray-500">
-                      Timeline: <span className="font-medium">{item.timeline}</span>
+                      Timeline:{" "}
+                      <span className="font-medium">{item.timeline}</span>
                     </div>
                   )}
                 </div>
@@ -189,7 +192,9 @@ export function RecommendationSection({
                     </div>
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-gray-900 mb-1">{step.step}</p>
+                    <p className="font-medium text-gray-900 mb-1">
+                      {step.step}
+                    </p>
                     <div className="flex flex-wrap gap-3 text-xs text-gray-600">
                       {step.owner && (
                         <span className="flex items-center">

--- a/src/components/module/summary-recommendation-section.tsx
+++ b/src/components/module/summary-recommendation-section.tsx
@@ -71,8 +71,11 @@ export function SummaryRecommendationSection({
   const [summaryAudioUrl, setSummaryAudioUrl] = useState<string | null>(null);
   const summaryAudioRef = useRef<HTMLAudioElement>(null);
 
-  const [isPlayingRecommendationAudio, setIsPlayingRecommendationAudio] = useState(false);
-  const [recommendationAudioUrl, setRecommendationAudioUrl] = useState<string | null>(null);
+  const [isPlayingRecommendationAudio, setIsPlayingRecommendationAudio] =
+    useState(false);
+  const [recommendationAudioUrl, setRecommendationAudioUrl] = useState<
+    string | null
+  >(null);
   const recommendationAudioRef = useRef<HTMLAudioElement>(null);
 
   const handlePlaySummaryAudio = async () => {
@@ -144,7 +147,9 @@ export function SummaryRecommendationSection({
             <CardHeader className="flex flex-row items-start justify-between">
               <div className="flex-1">
                 <CardTitle>{summaryTitle}</CardTitle>
-                <p className="text-sm text-gray-600 mt-1">{summaryDescription}</p>
+                <p className="text-sm text-gray-600 mt-1">
+                  {summaryDescription}
+                </p>
               </div>
               <Button
                 variant="outline"
@@ -184,7 +189,9 @@ export function SummaryRecommendationSection({
           {summaryMetrics.length > 0 && (
             <Card>
               <CardHeader>
-                <CardTitle className="text-lg">Key Metrics & Insights</CardTitle>
+                <CardTitle className="text-lg">
+                  Key Metrics & Insights
+                </CardTitle>
               </CardHeader>
               <CardContent>
                 <div className="overflow-x-auto">
@@ -243,7 +250,9 @@ export function SummaryRecommendationSection({
             <CardHeader className="flex flex-row items-start justify-between">
               <div className="flex-1">
                 <CardTitle>{recommendationTitle}</CardTitle>
-                <p className="text-sm text-gray-600 mt-1">{recommendationDescription}</p>
+                <p className="text-sm text-gray-600 mt-1">
+                  {recommendationDescription}
+                </p>
               </div>
               <Button
                 variant="outline"
@@ -306,7 +315,8 @@ export function SummaryRecommendationSection({
                           </div>
                         </div>
                         <Badge className={getPriorityColor(item.priority)}>
-                          {item.priority.charAt(0).toUpperCase() + item.priority.slice(1)}
+                          {item.priority.charAt(0).toUpperCase() +
+                            item.priority.slice(1)}
                         </Badge>
                       </div>
                       <p className="text-gray-600 text-sm ml-11 mb-2">
@@ -314,7 +324,8 @@ export function SummaryRecommendationSection({
                       </p>
                       {item.timeline && (
                         <div className="ml-11 text-xs text-gray-500">
-                          Timeline: <span className="font-medium">{item.timeline}</span>
+                          Timeline:{" "}
+                          <span className="font-medium">{item.timeline}</span>
                         </div>
                       )}
                     </div>
@@ -343,7 +354,9 @@ export function SummaryRecommendationSection({
                         </div>
                       </div>
                       <div className="flex-1 min-w-0">
-                        <p className="font-medium text-gray-900 mb-1 text-sm">{step.step}</p>
+                        <p className="font-medium text-gray-900 mb-1 text-sm">
+                          {step.step}
+                        </p>
                         <div className="flex flex-wrap gap-3 text-xs text-gray-600">
                           {step.owner && (
                             <span className="flex items-center">

--- a/src/components/module/summary-recommendation-section.tsx
+++ b/src/components/module/summary-recommendation-section.tsx
@@ -1,0 +1,372 @@
+import React, { useState, useRef } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Play, Pause } from "lucide-react";
+
+interface SummaryItem {
+  index: number;
+  title: string;
+  value: string | number;
+  unit?: string;
+  insight: string;
+}
+
+interface ActionItem {
+  index: number;
+  title: string;
+  description: string;
+  priority: "high" | "medium" | "low";
+  timeline?: string;
+}
+
+interface NextStep {
+  index: number;
+  step: string;
+  owner?: string;
+  dueDate?: string;
+}
+
+interface SummaryRecommendationProps {
+  summaryTitle?: string;
+  summaryDescription?: string;
+  summaryText: string;
+  summaryMetrics: SummaryItem[];
+  recommendationTitle?: string;
+  recommendationDescription?: string;
+  recommendationText: string;
+  actionItems: ActionItem[];
+  nextSteps: NextStep[];
+  onGenerateSummaryAudio?: () => Promise<string>;
+  onGenerateRecommendationAudio?: () => Promise<string>;
+}
+
+const getPriorityColor = (priority: "high" | "medium" | "low") => {
+  switch (priority) {
+    case "high":
+      return "bg-red-100 text-red-800";
+    case "medium":
+      return "bg-yellow-100 text-yellow-800";
+    case "low":
+      return "bg-green-100 text-green-800";
+    default:
+      return "bg-gray-100 text-gray-800";
+  }
+};
+
+export function SummaryRecommendationSection({
+  summaryTitle = "Summary",
+  summaryDescription = "Key metrics and insights from this module",
+  summaryText,
+  summaryMetrics,
+  recommendationTitle = "Recommendations",
+  recommendationDescription = "Strategic recommendations and action items",
+  recommendationText,
+  actionItems,
+  nextSteps,
+  onGenerateSummaryAudio,
+  onGenerateRecommendationAudio,
+}: SummaryRecommendationProps) {
+  const [isPlayingSummaryAudio, setIsPlayingSummaryAudio] = useState(false);
+  const [summaryAudioUrl, setSummaryAudioUrl] = useState<string | null>(null);
+  const summaryAudioRef = useRef<HTMLAudioElement>(null);
+
+  const [isPlayingRecommendationAudio, setIsPlayingRecommendationAudio] = useState(false);
+  const [recommendationAudioUrl, setRecommendationAudioUrl] = useState<string | null>(null);
+  const recommendationAudioRef = useRef<HTMLAudioElement>(null);
+
+  const handlePlaySummaryAudio = async () => {
+    try {
+      if (!summaryAudioUrl && onGenerateSummaryAudio) {
+        const url = await onGenerateSummaryAudio();
+        setSummaryAudioUrl(url);
+        setTimeout(() => {
+          if (summaryAudioRef.current) {
+            summaryAudioRef.current.play();
+            setIsPlayingSummaryAudio(true);
+          }
+        }, 100);
+      } else if (summaryAudioRef.current) {
+        if (isPlayingSummaryAudio) {
+          summaryAudioRef.current.pause();
+          setIsPlayingSummaryAudio(false);
+        } else {
+          summaryAudioRef.current.play();
+          setIsPlayingSummaryAudio(true);
+        }
+      }
+    } catch (error) {
+      console.error("Error playing summary audio:", error);
+    }
+  };
+
+  const handlePlayRecommendationAudio = async () => {
+    try {
+      if (!recommendationAudioUrl && onGenerateRecommendationAudio) {
+        const url = await onGenerateRecommendationAudio();
+        setRecommendationAudioUrl(url);
+        setTimeout(() => {
+          if (recommendationAudioRef.current) {
+            recommendationAudioRef.current.play();
+            setIsPlayingRecommendationAudio(true);
+          }
+        }, 100);
+      } else if (recommendationAudioRef.current) {
+        if (isPlayingRecommendationAudio) {
+          recommendationAudioRef.current.pause();
+          setIsPlayingRecommendationAudio(false);
+        } else {
+          recommendationAudioRef.current.play();
+          setIsPlayingRecommendationAudio(true);
+        }
+      }
+    } catch (error) {
+      console.error("Error playing recommendation audio:", error);
+    }
+  };
+
+  const handleSummaryAudioEnded = () => {
+    setIsPlayingSummaryAudio(false);
+  };
+
+  const handleRecommendationAudioEnded = () => {
+    setIsPlayingRecommendationAudio(false);
+  };
+
+  return (
+    <div className="space-y-8">
+      {/* Two-Column Layout */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {/* Summary Column */}
+        <div className="space-y-6">
+          {/* Summary Note Card */}
+          <Card>
+            <CardHeader className="flex flex-row items-start justify-between">
+              <div className="flex-1">
+                <CardTitle>{summaryTitle}</CardTitle>
+                <p className="text-sm text-gray-600 mt-1">{summaryDescription}</p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handlePlaySummaryAudio}
+                className="flex items-center gap-2 ml-4 flex-shrink-0"
+              >
+                {isPlayingSummaryAudio ? (
+                  <>
+                    <Pause className="h-4 w-4" />
+                    Pause
+                  </>
+                ) : (
+                  <>
+                    <Play className="h-4 w-4" />
+                    Play Audio
+                  </>
+                )}
+              </Button>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                <p className="text-gray-700 leading-relaxed whitespace-pre-wrap">
+                  {summaryText}
+                </p>
+              </div>
+              <audio
+                ref={summaryAudioRef}
+                src={summaryAudioUrl || ""}
+                onEnded={handleSummaryAudioEnded}
+                className="hidden"
+              />
+            </CardContent>
+          </Card>
+
+          {/* Summary Metrics Table */}
+          {summaryMetrics.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Key Metrics & Insights</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="overflow-x-auto">
+                  <table className="w-full">
+                    <thead>
+                      <tr className="border-b border-gray-200">
+                        <th className="text-left py-3 px-4 font-semibold text-gray-700 text-sm">
+                          Index
+                        </th>
+                        <th className="text-left py-3 px-4 font-semibold text-gray-700 text-sm">
+                          Metric
+                        </th>
+                        <th className="text-left py-3 px-4 font-semibold text-gray-700 text-sm">
+                          Value
+                        </th>
+                        <th className="text-left py-3 px-4 font-semibold text-gray-700 text-sm">
+                          Insight
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {summaryMetrics.map((metric, idx) => (
+                        <tr
+                          key={idx}
+                          className="border-b border-gray-100 hover:bg-gray-50 transition-colors"
+                        >
+                          <td className="py-3 px-4 text-gray-600 font-medium text-sm">
+                            {metric.index}
+                          </td>
+                          <td className="py-3 px-4 text-gray-900 font-medium text-sm">
+                            {metric.title}
+                          </td>
+                          <td className="py-3 px-4 text-gray-700 text-sm">
+                            <span className="font-semibold">
+                              {metric.value}
+                              {metric.unit && ` ${metric.unit}`}
+                            </span>
+                          </td>
+                          <td className="py-3 px-4 text-gray-600 text-xs">
+                            {metric.insight}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        {/* Recommendation Column */}
+        <div className="space-y-6">
+          {/* Recommendation Note Card */}
+          <Card>
+            <CardHeader className="flex flex-row items-start justify-between">
+              <div className="flex-1">
+                <CardTitle>{recommendationTitle}</CardTitle>
+                <p className="text-sm text-gray-600 mt-1">{recommendationDescription}</p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handlePlayRecommendationAudio}
+                className="flex items-center gap-2 ml-4 flex-shrink-0"
+              >
+                {isPlayingRecommendationAudio ? (
+                  <>
+                    <Pause className="h-4 w-4" />
+                    Pause
+                  </>
+                ) : (
+                  <>
+                    <Play className="h-4 w-4" />
+                    Play Audio
+                  </>
+                )}
+              </Button>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
+                <p className="text-gray-700 leading-relaxed whitespace-pre-wrap">
+                  {recommendationText}
+                </p>
+              </div>
+              <audio
+                ref={recommendationAudioRef}
+                src={recommendationAudioUrl || ""}
+                onEnded={handleRecommendationAudioEnded}
+                className="hidden"
+              />
+            </CardContent>
+          </Card>
+
+          {/* Action Items and Next Steps */}
+          {actionItems.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Action Items</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-4">
+                  {actionItems.map((item, idx) => (
+                    <div
+                      key={idx}
+                      className="border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow"
+                    >
+                      <div className="flex items-start justify-between gap-4 mb-2">
+                        <div className="flex items-center gap-3 flex-1">
+                          <div className="flex-shrink-0">
+                            <span className="inline-flex items-center justify-center h-8 w-8 rounded-full bg-blue-100 text-blue-600 font-semibold text-sm">
+                              {item.index}
+                            </span>
+                          </div>
+                          <div className="flex-1">
+                            <h4 className="font-semibold text-gray-900 text-sm">
+                              {item.title}
+                            </h4>
+                          </div>
+                        </div>
+                        <Badge className={getPriorityColor(item.priority)}>
+                          {item.priority.charAt(0).toUpperCase() + item.priority.slice(1)}
+                        </Badge>
+                      </div>
+                      <p className="text-gray-600 text-sm ml-11 mb-2">
+                        {item.description}
+                      </p>
+                      {item.timeline && (
+                        <div className="ml-11 text-xs text-gray-500">
+                          Timeline: <span className="font-medium">{item.timeline}</span>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Next Steps */}
+          {nextSteps.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Next Steps</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-4">
+                  {nextSteps.map((step, idx) => (
+                    <div
+                      key={idx}
+                      className="flex gap-4 pb-4 border-b border-gray-100 last:pb-0 last:border-0"
+                    >
+                      <div className="flex-shrink-0">
+                        <div className="flex items-center justify-center h-8 w-8 rounded-full bg-green-100 text-green-600 font-semibold text-sm">
+                          {step.index}
+                        </div>
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="font-medium text-gray-900 mb-1 text-sm">{step.step}</p>
+                        <div className="flex flex-wrap gap-3 text-xs text-gray-600">
+                          {step.owner && (
+                            <span className="flex items-center">
+                              <span className="font-medium">Owner:</span>
+                              <span className="ml-1">{step.owner}</span>
+                            </span>
+                          )}
+                          {step.dueDate && (
+                            <span className="flex items-center">
+                              <span className="font-medium">Due:</span>
+                              <span className="ml-1">{step.dueDate}</span>
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/module/summary-section.tsx
+++ b/src/components/module/summary-section.tsx
@@ -1,0 +1,161 @@
+import React, { useState, useRef } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Play, Pause, Volume2 } from "lucide-react";
+
+interface SummaryItem {
+  index: number;
+  title: string;
+  value: string | number;
+  unit?: string;
+  insight: string;
+}
+
+interface SummarySectionProps {
+  title?: string;
+  description?: string;
+  summaryText: string;
+  metrics: SummaryItem[];
+  onGenerateAudio?: () => Promise<string>;
+}
+
+export function SummarySection({
+  title = "Summary",
+  description = "Key metrics and insights from this module",
+  summaryText,
+  metrics,
+  onGenerateAudio,
+}: SummarySectionProps) {
+  const [isPlayingAudio, setIsPlayingAudio] = useState(false);
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  const handlePlayAudio = async () => {
+    try {
+      if (!audioUrl && onGenerateAudio) {
+        const url = await onGenerateAudio();
+        setAudioUrl(url);
+        setTimeout(() => {
+          if (audioRef.current) {
+            audioRef.current.play();
+            setIsPlayingAudio(true);
+          }
+        }, 100);
+      } else if (audioRef.current) {
+        if (isPlayingAudio) {
+          audioRef.current.pause();
+          setIsPlayingAudio(false);
+        } else {
+          audioRef.current.play();
+          setIsPlayingAudio(true);
+        }
+      }
+    } catch (error) {
+      console.error("Error playing audio:", error);
+    }
+  };
+
+  const handleAudioEnded = () => {
+    setIsPlayingAudio(false);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Summary Note Card */}
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between">
+          <div className="flex-1">
+            <CardTitle>{title}</CardTitle>
+            <p className="text-sm text-gray-600 mt-1">{description}</p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handlePlayAudio}
+            className="flex items-center gap-2 ml-4"
+          >
+            {isPlayingAudio ? (
+              <>
+                <Pause className="h-4 w-4" />
+                Pause
+              </>
+            ) : (
+              <>
+                <Play className="h-4 w-4" />
+                Play Audio
+              </>
+            )}
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+            <p className="text-gray-700 leading-relaxed whitespace-pre-wrap">
+              {summaryText}
+            </p>
+          </div>
+          <audio
+            ref={audioRef}
+            src={audioUrl || ""}
+            onEnded={handleAudioEnded}
+            className="hidden"
+          />
+        </CardContent>
+      </Card>
+
+      {/* Metrics Table */}
+      {metrics.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Key Metrics & Insights</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-gray-200">
+                    <th className="text-left py-3 px-4 font-semibold text-gray-700">
+                      Index
+                    </th>
+                    <th className="text-left py-3 px-4 font-semibold text-gray-700">
+                      Metric
+                    </th>
+                    <th className="text-left py-3 px-4 font-semibold text-gray-700">
+                      Value
+                    </th>
+                    <th className="text-left py-3 px-4 font-semibold text-gray-700">
+                      Insight
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {metrics.map((metric, idx) => (
+                    <tr
+                      key={idx}
+                      className="border-b border-gray-100 hover:bg-gray-50 transition-colors"
+                    >
+                      <td className="py-3 px-4 text-gray-600 font-medium">
+                        {metric.index}
+                      </td>
+                      <td className="py-3 px-4 text-gray-900 font-medium">
+                        {metric.title}
+                      </td>
+                      <td className="py-3 px-4 text-gray-700">
+                        <span className="font-semibold">
+                          {metric.value}
+                          {metric.unit && ` ${metric.unit}`}
+                        </span>
+                      </td>
+                      <td className="py-3 px-4 text-gray-600 text-sm">
+                        {metric.insight}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/pages/BusinessForecast.tsx
+++ b/src/pages/BusinessForecast.tsx
@@ -17,6 +17,8 @@ import { ScenarioPlanningComponent } from "@/components/business/scenario-planni
 import { BusinessMetricsTable } from "@/components/business/business-metrics-table";
 import { FinancialLayout } from "@/components/business/financial-layout";
 import { DocumentsSection } from "@/components/business/documents-section";
+import { SummarySection } from "@/components/module/summary-section";
+import { RecommendationSection } from "@/components/module/recommendation-section";
 import {
   costStructure as mockCosts,
   cashFlowForecast as mockCashFlow,

--- a/src/pages/BusinessForecast.tsx
+++ b/src/pages/BusinessForecast.tsx
@@ -224,6 +224,142 @@ const BusinessForecast = () => {
             </section>
           </TabsContent>
 
+          <TabsContent value="summary" className="space-y-8">
+            <SummarySection
+              title="Business Forecast Summary"
+              description="Executive summary with key metrics and insights"
+              summaryText={`1. REVENUE OVERVIEW
+Current annual revenue target is set at $13.7M with ${customerProfiles.length} distinct customer segments identified. The forecast includes ${scenarios.length} scenario models to cover conservative, base, and aggressive growth cases.
+
+2. CUSTOMER BASE
+The business operates across multiple customer segments with varying demand patterns. Average order values and segment preferences have been analyzed to inform revenue projections and marketing strategies.
+
+3. KEY PERFORMANCE METRICS
+${kpis.length} key performance indicators are being tracked across operational, financial, and strategic dimensions. These KPIs provide early signals of business health and market opportunity.
+
+4. FORECAST METHODOLOGY
+The forecast employs Monte Carlo simulations, linear regression analysis, and scenario planning to account for uncertainty and provide a range of potential outcomes.
+
+5. NEXT QUARTER OUTLOOK
+Q1 2025 focuses on foundation building, with emphasis on customer retention and operational efficiency improvements. Expected growth rate aligns with market expansion strategy.`}
+              metrics={[
+                {
+                  index: 1,
+                  title: "Annual Revenue Target",
+                  value: "$13.7M",
+                  insight: "Primary revenue goal for fiscal year",
+                },
+                {
+                  index: 2,
+                  title: "Customer Segments",
+                  value: customerProfiles.length,
+                  insight: "Active market segments being served",
+                },
+                {
+                  index: 3,
+                  title: "KPIs Tracked",
+                  value: kpis.length,
+                  insight: "Performance metrics under active monitoring",
+                },
+                {
+                  index: 4,
+                  title: "Scenario Models",
+                  value: scenarios.length,
+                  insight: "Planning scenarios for different market conditions",
+                },
+              ]}
+            />
+          </TabsContent>
+
+          <TabsContent value="recommendations" className="space-y-8">
+            <RecommendationSection
+              title="Business Forecast Recommendations"
+              description="Strategic recommendations and action items based on forecast analysis"
+              recommendationText={`1. REVENUE OPTIMIZATION
+Prioritize high-margin customer segments that show strongest growth potential. Consider dynamic pricing strategies for products with high elasticity. Implement customer lifetime value modeling to focus acquisition and retention efforts on most valuable segments.
+
+2. SCENARIO PLANNING
+Develop contingency plans for downside scenarios (20% revenue below base case). Establish trigger points for strategy adjustments based on key leading indicators. Quarterly scenario reviews to adapt planning assumptions as market conditions evolve.
+
+3. OPERATIONAL EFFICIENCY
+Target 10-15% improvement in cost structure through process optimization. Invest in automation for repetitive tasks. Negotiate supplier contracts aligned with growth trajectory.
+
+4. CASH FLOW MANAGEMENT
+Establish working capital reserves equivalent to 60 days of operating expenses. Monitor cash conversion cycle monthly. Implement early warning system for cash flow stress signals.
+
+5. MARKET EXPANSION
+Identify 2-3 new market segments or geographies for expansion in next 12 months. Allocate 15-20% of resources to innovation and market testing. Build partnerships with complementary service providers.`}
+              actionItems={[
+                {
+                  index: 1,
+                  title: "Segment Revenue Analysis",
+                  description:
+                    "Conduct detailed profitability analysis for each customer segment to identify high-margin opportunities and optimize pricing strategy",
+                  priority: "high",
+                  timeline: "Q1 2025",
+                },
+                {
+                  index: 2,
+                  title: "Cash Flow Forecasting System",
+                  description:
+                    "Implement daily cash flow tracking and weekly rolling forecasts to improve liquidity management and decision-making",
+                  priority: "high",
+                  timeline: "Q1 2025",
+                },
+                {
+                  index: 3,
+                  title: "Cost Reduction Initiative",
+                  description:
+                    "Launch cross-functional program to identify and eliminate wasteful spending while maintaining service quality",
+                  priority: "medium",
+                  timeline: "Q2 2025",
+                },
+                {
+                  index: 4,
+                  title: "KPI Dashboard Enhancement",
+                  description:
+                    "Expand KPI dashboard with real-time alerts for critical metrics and predictive analytics for early warning signals",
+                  priority: "medium",
+                  timeline: "Q2 2025",
+                },
+                {
+                  index: 5,
+                  title: "Market Expansion Strategy",
+                  description:
+                    "Research and develop entry strategy for adjacent market segments or geographies with strong growth potential",
+                  priority: "low",
+                  timeline: "Q2-Q3 2025",
+                },
+              ]}
+              nextSteps={[
+                {
+                  index: 1,
+                  step: "Review and validate all revenue assumptions in the forecast model",
+                  owner: "Finance Team",
+                  dueDate: "End of Week 1",
+                },
+                {
+                  index: 2,
+                  step: "Conduct sensitivity analysis on key input variables",
+                  owner: "Analytics Team",
+                  dueDate: "End of Week 2",
+                },
+                {
+                  index: 3,
+                  step: "Present scenarios to executive team with recommended strategy",
+                  owner: "CFO",
+                  dueDate: "End of Month",
+                },
+                {
+                  index: 4,
+                  step: "Establish monthly forecast review cadence with updates",
+                  owner: "Planning Manager",
+                  dueDate: "Ongoing",
+                },
+              ]}
+            />
+          </TabsContent>
+
           <TabsContent value="tables" className="space-y-8">
             {/* Business Metrics Table */}
             <section>

--- a/src/pages/BusinessForecast.tsx
+++ b/src/pages/BusinessForecast.tsx
@@ -6,9 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { LoadingOverlay } from "@/components/ui/loading-spinner";
 import ModuleHeader from "@/components/ui/module-header";
-import {
-  TooltipProvider,
-} from "@/components/ui/tooltip";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { useBusinessData } from "@/hooks/useBusinessData";
 import { CustomerProfileComponent } from "@/components/business/customer-profile";
 import { RevenueProjections } from "@/components/business/revenue-projections";
@@ -75,158 +73,160 @@ const BusinessForecast = () => {
           connectionLabel="Live"
         />
 
-      <main className="container mx-auto px-4 py-8 space-y-8">
-        {/* Quick Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <Card>
-            <CardContent className="p-4">
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-economic-positive/10 rounded-lg">
-                  <DollarSign className="h-5 w-5 text-economic-positive" />
-                </div>
-                <div>
-                  <div className="text-sm text-muted-foreground">
-                    Annual Revenue Target
+        <main className="container mx-auto px-4 py-8 space-y-8">
+          {/* Quick Stats */}
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center gap-3">
+                  <div className="p-2 bg-economic-positive/10 rounded-lg">
+                    <DollarSign className="h-5 w-5 text-economic-positive" />
                   </div>
-                  <div className="text-lg font-bold">$13.7M</div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardContent className="p-4">
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-primary/10 rounded-lg">
-                  <Users className="h-5 w-5 text-primary" />
-                </div>
-                <div>
-                  <div className="text-sm text-muted-foreground">
-                    Customer Segments
-                  </div>
-                  <div className="text-lg font-bold">
-                    {customerProfiles.length}
+                  <div>
+                    <div className="text-sm text-muted-foreground">
+                      Annual Revenue Target
+                    </div>
+                    <div className="text-lg font-bold">$13.7M</div>
                   </div>
                 </div>
-              </div>
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
 
-          <Card>
-            <CardContent className="p-4">
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-economic-warning/10 rounded-lg">
-                  <Target className="h-5 w-5 text-economic-warning" />
-                </div>
-                <div>
-                  <div className="text-sm text-muted-foreground">
-                    KPIs Tracked
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center gap-3">
+                  <div className="p-2 bg-primary/10 rounded-lg">
+                    <Users className="h-5 w-5 text-primary" />
                   </div>
-                  <div className="text-lg font-bold">{kpis.length}</div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardContent className="p-4">
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-economic-neutral/10 rounded-lg">
-                  <BarChart3 className="h-5 w-5 text-economic-neutral" />
-                </div>
-                <div>
-                  <div className="text-sm text-muted-foreground">
-                    Scenarios Modeled
+                  <div>
+                    <div className="text-sm text-muted-foreground">
+                      Customer Segments
+                    </div>
+                    <div className="text-lg font-bold">
+                      {customerProfiles.length}
+                    </div>
                   </div>
-                  <div className="text-lg font-bold">{scenarios.length}</div>
                 </div>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
+              </CardContent>
+            </Card>
 
-        {/* Main Content Tabs */}
-        <Tabs defaultValue="overview" className="space-y-6">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <TabsList className="grid grid-cols-8 w-full sm:w-auto">
-              <TabsTrigger value="overview">Overview</TabsTrigger>
-              <TabsTrigger value="summary-recommendation">Summary & Recommendation</TabsTrigger>
-              <TabsTrigger value="tables">Tables</TabsTrigger>
-              <TabsTrigger value="revenue">Revenue</TabsTrigger>
-              <TabsTrigger value="costs">Costs</TabsTrigger>
-              <TabsTrigger value="planning">Planning</TabsTrigger>
-              <TabsTrigger value="analytics">Analytics</TabsTrigger>
-              <TabsTrigger value="documents">Documents</TabsTrigger>
-            </TabsList>
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center gap-3">
+                  <div className="p-2 bg-economic-warning/10 rounded-lg">
+                    <Target className="h-5 w-5 text-economic-warning" />
+                  </div>
+                  <div>
+                    <div className="text-sm text-muted-foreground">
+                      KPIs Tracked
+                    </div>
+                    <div className="text-lg font-bold">{kpis.length}</div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
 
-            <div className="flex items-center gap-2">
-              <Badge
-                variant={isConnected ? "default" : "destructive"}
-                className="flex items-center gap-1"
-              >
-                {isConnected ? (
-                  <Wifi className="h-3 w-3" />
-                ) : (
-                  <Activity className="h-3 w-3" />
-                )}
-                {isConnected ? "Live Data" : "Offline Mode"}
-              </Badge>
-              <Badge variant="outline" className="flex items-center gap-1">
-                <TrendingUp className="h-3 w-3" />
-                Forecast Active
-              </Badge>
-              {error && (
-                <Badge
-                  variant="destructive"
-                  className="flex items-center gap-1"
-                >
-                  <AlertTriangle className="h-3 w-3" />
-                  Data Sync Issue
-                </Badge>
-              )}
-            </div>
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center gap-3">
+                  <div className="p-2 bg-economic-neutral/10 rounded-lg">
+                    <BarChart3 className="h-5 w-5 text-economic-neutral" />
+                  </div>
+                  <div>
+                    <div className="text-sm text-muted-foreground">
+                      Scenarios Modeled
+                    </div>
+                    <div className="text-lg font-bold">{scenarios.length}</div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
           </div>
 
-          <TabsContent value="overview" className="space-y-8">
-            {/* Customer Profiles */}
-            <section>
-              <LoadingOverlay
-                isLoading={isLoading}
-                loadingText="Updating customer data..."
-              >
-                <CustomerProfileComponent profiles={customerProfiles} />
-              </LoadingOverlay>
-            </section>
+          {/* Main Content Tabs */}
+          <Tabs defaultValue="overview" className="space-y-6">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+              <TabsList className="grid grid-cols-8 w-full sm:w-auto">
+                <TabsTrigger value="overview">Overview</TabsTrigger>
+                <TabsTrigger value="summary-recommendation">
+                  Summary & Recommendation
+                </TabsTrigger>
+                <TabsTrigger value="tables">Tables</TabsTrigger>
+                <TabsTrigger value="revenue">Revenue</TabsTrigger>
+                <TabsTrigger value="costs">Costs</TabsTrigger>
+                <TabsTrigger value="planning">Planning</TabsTrigger>
+                <TabsTrigger value="analytics">Analytics</TabsTrigger>
+                <TabsTrigger value="documents">Documents</TabsTrigger>
+              </TabsList>
 
-            {/* Revenue Projections */}
-            <section>
-              <LoadingOverlay
-                isLoading={isLoading}
-                loadingText="Calculating revenue projections..."
-              >
-                <RevenueProjections projections={revenueProjections} />
-              </LoadingOverlay>
-            </section>
+              <div className="flex items-center gap-2">
+                <Badge
+                  variant={isConnected ? "default" : "destructive"}
+                  className="flex items-center gap-1"
+                >
+                  {isConnected ? (
+                    <Wifi className="h-3 w-3" />
+                  ) : (
+                    <Activity className="h-3 w-3" />
+                  )}
+                  {isConnected ? "Live Data" : "Offline Mode"}
+                </Badge>
+                <Badge variant="outline" className="flex items-center gap-1">
+                  <TrendingUp className="h-3 w-3" />
+                  Forecast Active
+                </Badge>
+                {error && (
+                  <Badge
+                    variant="destructive"
+                    className="flex items-center gap-1"
+                  >
+                    <AlertTriangle className="h-3 w-3" />
+                    Data Sync Issue
+                  </Badge>
+                )}
+              </div>
+            </div>
 
-            {/* Key Performance Indicators */}
-            <section>
-              <LoadingOverlay
-                isLoading={isLoading}
-                loadingText="Refreshing KPIs..."
-              >
-                <KPIDashboard
-                  kpis={kpis.slice(0, 6)}
-                  title="Key Performance Indicators"
-                />
-              </LoadingOverlay>
-            </section>
-          </TabsContent>
+            <TabsContent value="overview" className="space-y-8">
+              {/* Customer Profiles */}
+              <section>
+                <LoadingOverlay
+                  isLoading={isLoading}
+                  loadingText="Updating customer data..."
+                >
+                  <CustomerProfileComponent profiles={customerProfiles} />
+                </LoadingOverlay>
+              </section>
 
-          <TabsContent value="summary-recommendation" className="space-y-8">
-            <SummaryRecommendationSection
-              summaryTitle="Business Forecast Summary"
-              summaryDescription="Executive summary with key metrics and insights"
-              summaryText={`1. REVENUE OVERVIEW
+              {/* Revenue Projections */}
+              <section>
+                <LoadingOverlay
+                  isLoading={isLoading}
+                  loadingText="Calculating revenue projections..."
+                >
+                  <RevenueProjections projections={revenueProjections} />
+                </LoadingOverlay>
+              </section>
+
+              {/* Key Performance Indicators */}
+              <section>
+                <LoadingOverlay
+                  isLoading={isLoading}
+                  loadingText="Refreshing KPIs..."
+                >
+                  <KPIDashboard
+                    kpis={kpis.slice(0, 6)}
+                    title="Key Performance Indicators"
+                  />
+                </LoadingOverlay>
+              </section>
+            </TabsContent>
+
+            <TabsContent value="summary-recommendation" className="space-y-8">
+              <SummaryRecommendationSection
+                summaryTitle="Business Forecast Summary"
+                summaryDescription="Executive summary with key metrics and insights"
+                summaryText={`1. REVENUE OVERVIEW
 Current annual revenue target is set at $13.7M with ${customerProfiles.length} distinct customer segments identified. The forecast includes ${scenarios.length} scenario models to cover conservative, base, and aggressive growth cases.
 
 2. CUSTOMER BASE
@@ -240,35 +240,36 @@ The forecast employs Monte Carlo simulations, linear regression analysis, and sc
 
 5. NEXT QUARTER OUTLOOK
 Q1 2025 focuses on foundation building, with emphasis on customer retention and operational efficiency improvements. Expected growth rate aligns with market expansion strategy.`}
-              summaryMetrics={[
-                {
-                  index: 1,
-                  title: "Annual Revenue Target",
-                  value: "$13.7M",
-                  insight: "Primary revenue goal for fiscal year",
-                },
-                {
-                  index: 2,
-                  title: "Customer Segments",
-                  value: customerProfiles.length,
-                  insight: "Active market segments being served",
-                },
-                {
-                  index: 3,
-                  title: "KPIs Tracked",
-                  value: kpis.length,
-                  insight: "Performance metrics under active monitoring",
-                },
-                {
-                  index: 4,
-                  title: "Scenario Models",
-                  value: scenarios.length,
-                  insight: "Planning scenarios for different market conditions",
-                },
-              ]}
-              recommendationTitle="Business Forecast Recommendations"
-              recommendationDescription="Strategic recommendations and action items based on forecast analysis"
-              recommendationText={`1. REVENUE OPTIMIZATION
+                summaryMetrics={[
+                  {
+                    index: 1,
+                    title: "Annual Revenue Target",
+                    value: "$13.7M",
+                    insight: "Primary revenue goal for fiscal year",
+                  },
+                  {
+                    index: 2,
+                    title: "Customer Segments",
+                    value: customerProfiles.length,
+                    insight: "Active market segments being served",
+                  },
+                  {
+                    index: 3,
+                    title: "KPIs Tracked",
+                    value: kpis.length,
+                    insight: "Performance metrics under active monitoring",
+                  },
+                  {
+                    index: 4,
+                    title: "Scenario Models",
+                    value: scenarios.length,
+                    insight:
+                      "Planning scenarios for different market conditions",
+                  },
+                ]}
+                recommendationTitle="Business Forecast Recommendations"
+                recommendationDescription="Strategic recommendations and action items based on forecast analysis"
+                recommendationText={`1. REVENUE OPTIMIZATION
 Prioritize high-margin customer segments that show strongest growth potential. Consider dynamic pricing strategies for products with high elasticity. Implement customer lifetime value modeling to focus acquisition and retention efforts on most valuable segments.
 
 2. SCENARIO PLANNING
@@ -282,448 +283,469 @@ Establish working capital reserves equivalent to 60 days of operating expenses. 
 
 5. MARKET EXPANSION
 Identify 2-3 new market segments or geographies for expansion in next 12 months. Allocate 15-20% of resources to innovation and market testing. Build partnerships with complementary service providers.`}
-              actionItems={[
-                {
-                  index: 1,
-                  title: "Segment Revenue Analysis",
-                  description:
-                    "Conduct detailed profitability analysis for each customer segment to identify high-margin opportunities and optimize pricing strategy",
-                  priority: "high",
-                  timeline: "Q1 2025",
-                },
-                {
-                  index: 2,
-                  title: "Cash Flow Forecasting System",
-                  description:
-                    "Implement daily cash flow tracking and weekly rolling forecasts to improve liquidity management and decision-making",
-                  priority: "high",
-                  timeline: "Q1 2025",
-                },
-                {
-                  index: 3,
-                  title: "Cost Reduction Initiative",
-                  description:
-                    "Launch cross-functional program to identify and eliminate wasteful spending while maintaining service quality",
-                  priority: "medium",
-                  timeline: "Q2 2025",
-                },
-                {
-                  index: 4,
-                  title: "KPI Dashboard Enhancement",
-                  description:
-                    "Expand KPI dashboard with real-time alerts for critical metrics and predictive analytics for early warning signals",
-                  priority: "medium",
-                  timeline: "Q2 2025",
-                },
-                {
-                  index: 5,
-                  title: "Market Expansion Strategy",
-                  description:
-                    "Research and develop entry strategy for adjacent market segments or geographies with strong growth potential",
-                  priority: "low",
-                  timeline: "Q2-Q3 2025",
-                },
-              ]}
-              nextSteps={[
-                {
-                  index: 1,
-                  step: "Review and validate all revenue assumptions in the forecast model",
-                  owner: "Finance Team",
-                  dueDate: "End of Week 1",
-                },
-                {
-                  index: 2,
-                  step: "Conduct sensitivity analysis on key input variables",
-                  owner: "Analytics Team",
-                  dueDate: "End of Week 2",
-                },
-                {
-                  index: 3,
-                  step: "Present scenarios to executive team with recommended strategy",
-                  owner: "CFO",
-                  dueDate: "End of Month",
-                },
-                {
-                  index: 4,
-                  step: "Establish monthly forecast review cadence with updates",
-                  owner: "Planning Manager",
-                  dueDate: "Ongoing",
-                },
-              ]}
-            />
-          </TabsContent>
+                actionItems={[
+                  {
+                    index: 1,
+                    title: "Segment Revenue Analysis",
+                    description:
+                      "Conduct detailed profitability analysis for each customer segment to identify high-margin opportunities and optimize pricing strategy",
+                    priority: "high",
+                    timeline: "Q1 2025",
+                  },
+                  {
+                    index: 2,
+                    title: "Cash Flow Forecasting System",
+                    description:
+                      "Implement daily cash flow tracking and weekly rolling forecasts to improve liquidity management and decision-making",
+                    priority: "high",
+                    timeline: "Q1 2025",
+                  },
+                  {
+                    index: 3,
+                    title: "Cost Reduction Initiative",
+                    description:
+                      "Launch cross-functional program to identify and eliminate wasteful spending while maintaining service quality",
+                    priority: "medium",
+                    timeline: "Q2 2025",
+                  },
+                  {
+                    index: 4,
+                    title: "KPI Dashboard Enhancement",
+                    description:
+                      "Expand KPI dashboard with real-time alerts for critical metrics and predictive analytics for early warning signals",
+                    priority: "medium",
+                    timeline: "Q2 2025",
+                  },
+                  {
+                    index: 5,
+                    title: "Market Expansion Strategy",
+                    description:
+                      "Research and develop entry strategy for adjacent market segments or geographies with strong growth potential",
+                    priority: "low",
+                    timeline: "Q2-Q3 2025",
+                  },
+                ]}
+                nextSteps={[
+                  {
+                    index: 1,
+                    step: "Review and validate all revenue assumptions in the forecast model",
+                    owner: "Finance Team",
+                    dueDate: "End of Week 1",
+                  },
+                  {
+                    index: 2,
+                    step: "Conduct sensitivity analysis on key input variables",
+                    owner: "Analytics Team",
+                    dueDate: "End of Week 2",
+                  },
+                  {
+                    index: 3,
+                    step: "Present scenarios to executive team with recommended strategy",
+                    owner: "CFO",
+                    dueDate: "End of Month",
+                  },
+                  {
+                    index: 4,
+                    step: "Establish monthly forecast review cadence with updates",
+                    owner: "Planning Manager",
+                    dueDate: "Ongoing",
+                  },
+                ]}
+              />
+            </TabsContent>
 
-          <TabsContent value="tables" className="space-y-8">
-            {/* Business Metrics Table */}
-            <section>
-              <BusinessMetricsTable />
-            </section>
+            <TabsContent value="tables" className="space-y-8">
+              {/* Business Metrics Table */}
+              <section>
+                <BusinessMetricsTable />
+              </section>
 
-            {/* Financial Layout Metrics */}
-            <section>
-              <FinancialLayout />
-            </section>
-          </TabsContent>
+              {/* Financial Layout Metrics */}
+              <section>
+                <FinancialLayout />
+              </section>
+            </TabsContent>
 
-          <TabsContent value="revenue" className="space-y-8">
-            {/* Revenue Projections */}
-            <section>
-              <RevenueProjections projections={revenueProjections} />
-            </section>
+            <TabsContent value="revenue" className="space-y-8">
+              {/* Revenue Projections */}
+              <section>
+                <RevenueProjections projections={revenueProjections} />
+              </section>
 
-            {/* Customer Demand Analysis */}
-            <section>
-              <CustomerProfileComponent profiles={customerProfiles} />
-            </section>
+              {/* Customer Demand Analysis */}
+              <section>
+                <CustomerProfileComponent profiles={customerProfiles} />
+              </section>
 
-            {/* Revenue Breakdown */}
-            <section>
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-lg flex items-center gap-2">
-                    <PieChart className="h-5 w-5" />
-                    Revenue Breakdown Analysis
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div className="space-y-3">
-                      <h4 className="font-semibold text-sm">
-                        By Customer Segment
-                      </h4>
-                      <div className="space-y-2">
-                        {customerProfiles.map((profile, index) => (
-                          <div
-                            key={profile.id}
-                            className="flex items-center justify-between"
-                          >
-                            <span className="text-sm">{profile.segment}</span>
-                            <span className="font-medium">
-                              $
-                              {(
-                                (profile.demandAssumption *
-                                  profile.avgOrderValue) /
-                                1000000
-                              ).toFixed(1)}
-                              M
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-
-                    <div className="space-y-3">
-                      <h4 className="font-semibold text-sm">
-                        Growth Trajectory
-                      </h4>
-                      <div className="space-y-2 text-sm text-muted-foreground">
-                        <p>• Q1 2025: Foundation building phase</p>
-                        <p>• Q2 2025: Accelerated growth period</p>
-                        <p>• Q3 2025: Market expansion phase</p>
-                        <p>• Q4 2025: Optimization and scaling</p>
-                        <div className="mt-3">
-                          <Link to="/growth-planning">
-                            <Button variant="outline" size="sm" className="border-green-200 text-green-700">
-                              <Target className="h-4 w-4 mr-2" />
-                              Plan Growth Strategy
-                            </Button>
-                          </Link>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </section>
-          </TabsContent>
-
-          <TabsContent value="costs" className="space-y-8">
-            {/* Cost Structure */}
-            <section>
-              <LoadingOverlay
-                isLoading={isLoading}
-                loadingText="Analyzing cost structure..."
-              >
+              {/* Revenue Breakdown */}
+              <section>
                 <Card>
                   <CardHeader>
                     <CardTitle className="text-lg flex items-center gap-2">
                       <PieChart className="h-5 w-5" />
-                      Cost of Goods Sold (COGS) & Operating Expenses
+                      Revenue Breakdown Analysis
                     </CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                      {mockCosts.map((cost) => (
-                        <Card key={cost.id} className="p-4">
-                          <div className="space-y-3">
-                            <div className="flex items-center justify-between">
-                              <h4 className="font-medium text-sm">
-                                {cost.category}
-                              </h4>
-                              <Badge
-                                variant={
-                                  cost.type === "COGS" ? "default" : "secondary"
-                                }
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                      <div className="space-y-3">
+                        <h4 className="font-semibold text-sm">
+                          By Customer Segment
+                        </h4>
+                        <div className="space-y-2">
+                          {customerProfiles.map((profile, index) => (
+                            <div
+                              key={profile.id}
+                              className="flex items-center justify-between"
+                            >
+                              <span className="text-sm">{profile.segment}</span>
+                              <span className="font-medium">
+                                $
+                                {(
+                                  (profile.demandAssumption *
+                                    profile.avgOrderValue) /
+                                  1000000
+                                ).toFixed(1)}
+                                M
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+
+                      <div className="space-y-3">
+                        <h4 className="font-semibold text-sm">
+                          Growth Trajectory
+                        </h4>
+                        <div className="space-y-2 text-sm text-muted-foreground">
+                          <p>• Q1 2025: Foundation building phase</p>
+                          <p>• Q2 2025: Accelerated growth period</p>
+                          <p>• Q3 2025: Market expansion phase</p>
+                          <p>• Q4 2025: Optimization and scaling</p>
+                          <div className="mt-3">
+                            <Link to="/growth-planning">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="border-green-200 text-green-700"
                               >
-                                {cost.type}
-                              </Badge>
-                            </div>
-                            <div className="space-y-2">
-                              <div className="flex items-center justify-between">
-                                <span className="text-sm text-muted-foreground">
-                                  Amount
-                                </span>
-                                <span className="font-semibold">
-                                  ${(cost.amount / 1000).toFixed(0)}K
-                                </span>
-                              </div>
-                              <div className="flex items-center justify-between">
-                                <span className="text-sm text-muted-foreground">
-                                  % of Total
-                                </span>
-                                <span className="font-medium">
-                                  {cost.percentage}%
-                                </span>
-                              </div>
-                              <div className="flex items-center justify-between">
-                                <span className="text-sm text-muted-foreground">
-                                  Type
-                                </span>
-                                <Badge variant="outline" className="text-xs">
-                                  {cost.variability}
-                                </Badge>
-                              </div>
-                            </div>
+                                <Target className="h-4 w-4 mr-2" />
+                                Plan Growth Strategy
+                              </Button>
+                            </Link>
                           </div>
-                        </Card>
-                      ))}
+                        </div>
+                      </div>
                     </div>
                   </CardContent>
                 </Card>
-              </LoadingOverlay>
-            </section>
+              </section>
+            </TabsContent>
 
-            {/* Cash Flow Forecast */}
-            <section>
-              <LoadingOverlay
-                isLoading={isLoading}
-                loadingText="Updating cash flow..."
-              >
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="text-lg flex items-center gap-2">
-                      <BarChart3 className="h-5 w-5" />
-                      Cash Flow Forecast
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="space-y-4">
-                      <div className="grid grid-cols-1 lg:grid-cols-6 gap-4">
-                        {mockCashFlow.map((flow) => (
-                          <Card key={flow.id} className="p-3">
-                            <div className="space-y-2">
-                              <h4 className="font-medium text-sm">
-                                {flow.month}
-                              </h4>
-                              <div className="space-y-1">
-                                <div className="flex justify-between text-xs">
-                                  <span className="text-muted-foreground">
-                                    Inflow
+            <TabsContent value="costs" className="space-y-8">
+              {/* Cost Structure */}
+              <section>
+                <LoadingOverlay
+                  isLoading={isLoading}
+                  loadingText="Analyzing cost structure..."
+                >
+                  <Card>
+                    <CardHeader>
+                      <CardTitle className="text-lg flex items-center gap-2">
+                        <PieChart className="h-5 w-5" />
+                        Cost of Goods Sold (COGS) & Operating Expenses
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                        {mockCosts.map((cost) => (
+                          <Card key={cost.id} className="p-4">
+                            <div className="space-y-3">
+                              <div className="flex items-center justify-between">
+                                <h4 className="font-medium text-sm">
+                                  {cost.category}
+                                </h4>
+                                <Badge
+                                  variant={
+                                    cost.type === "COGS"
+                                      ? "default"
+                                      : "secondary"
+                                  }
+                                >
+                                  {cost.type}
+                                </Badge>
+                              </div>
+                              <div className="space-y-2">
+                                <div className="flex items-center justify-between">
+                                  <span className="text-sm text-muted-foreground">
+                                    Amount
                                   </span>
-                                  <span className="text-economic-positive">
-                                    ${(flow.cashInflow / 1000000).toFixed(1)}M
+                                  <span className="font-semibold">
+                                    ${(cost.amount / 1000).toFixed(0)}K
                                   </span>
                                 </div>
-                                <div className="flex justify-between text-xs">
-                                  <span className="text-muted-foreground">
-                                    Outflow
+                                <div className="flex items-center justify-between">
+                                  <span className="text-sm text-muted-foreground">
+                                    % of Total
                                   </span>
-                                  <span className="text-economic-negative">
-                                    ${(flow.cashOutflow / 1000000).toFixed(1)}M
+                                  <span className="font-medium">
+                                    {cost.percentage}%
                                   </span>
                                 </div>
-                                <div className="flex justify-between text-sm border-t pt-1">
-                                  <span className="font-medium">Net</span>
-                                  <span
-                                    className={
-                                      flow.netCashFlow > 0
-                                        ? "text-economic-positive"
-                                        : "text-economic-negative"
-                                    }
-                                  >
-                                    ${(flow.netCashFlow / 1000000).toFixed(1)}M
+                                <div className="flex items-center justify-between">
+                                  <span className="text-sm text-muted-foreground">
+                                    Type
                                   </span>
+                                  <Badge variant="outline" className="text-xs">
+                                    {cost.variability}
+                                  </Badge>
                                 </div>
                               </div>
                             </div>
                           </Card>
                         ))}
                       </div>
+                    </CardContent>
+                  </Card>
+                </LoadingOverlay>
+              </section>
+
+              {/* Cash Flow Forecast */}
+              <section>
+                <LoadingOverlay
+                  isLoading={isLoading}
+                  loadingText="Updating cash flow..."
+                >
+                  <Card>
+                    <CardHeader>
+                      <CardTitle className="text-lg flex items-center gap-2">
+                        <BarChart3 className="h-5 w-5" />
+                        Cash Flow Forecast
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="space-y-4">
+                        <div className="grid grid-cols-1 lg:grid-cols-6 gap-4">
+                          {mockCashFlow.map((flow) => (
+                            <Card key={flow.id} className="p-3">
+                              <div className="space-y-2">
+                                <h4 className="font-medium text-sm">
+                                  {flow.month}
+                                </h4>
+                                <div className="space-y-1">
+                                  <div className="flex justify-between text-xs">
+                                    <span className="text-muted-foreground">
+                                      Inflow
+                                    </span>
+                                    <span className="text-economic-positive">
+                                      ${(flow.cashInflow / 1000000).toFixed(1)}M
+                                    </span>
+                                  </div>
+                                  <div className="flex justify-between text-xs">
+                                    <span className="text-muted-foreground">
+                                      Outflow
+                                    </span>
+                                    <span className="text-economic-negative">
+                                      ${(flow.cashOutflow / 1000000).toFixed(1)}
+                                      M
+                                    </span>
+                                  </div>
+                                  <div className="flex justify-between text-sm border-t pt-1">
+                                    <span className="font-medium">Net</span>
+                                    <span
+                                      className={
+                                        flow.netCashFlow > 0
+                                          ? "text-economic-positive"
+                                          : "text-economic-negative"
+                                      }
+                                    >
+                                      ${(flow.netCashFlow / 1000000).toFixed(1)}
+                                      M
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </Card>
+                          ))}
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </LoadingOverlay>
+              </section>
+            </TabsContent>
+
+            <TabsContent value="planning" className="space-y-8">
+              {/* Scenario Planning */}
+              <section>
+                <LoadingOverlay
+                  isLoading={isLoading}
+                  loadingText="Updating scenarios..."
+                >
+                  <ScenarioPlanningComponent scenarios={scenarios} />
+                </LoadingOverlay>
+              </section>
+
+              {/* Risk & Assumption Analysis */}
+              <section>
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-lg flex items-center gap-2">
+                      <AlertTriangle className="h-5 w-5" />
+                      Risk & Assumption Analysis
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                      <div className="space-y-3">
+                        <h4 className="font-semibold text-sm">Key Risks</h4>
+                        <div className="space-y-2">
+                          <div className="flex items-center justify-between p-2 border rounded">
+                            <span className="text-sm">Market Competition</span>
+                            <Badge variant="destructive" className="text-xs">
+                              High
+                            </Badge>
+                          </div>
+                          <div className="flex items-center justify-between p-2 border rounded">
+                            <span className="text-sm">
+                              Supply Chain Disruption
+                            </span>
+                            <Badge className="text-xs bg-economic-warning text-economic-warning-foreground">
+                              Medium
+                            </Badge>
+                          </div>
+                          <div className="flex items-center justify-between p-2 border rounded">
+                            <span className="text-sm">Regulatory Changes</span>
+                            <Badge variant="secondary" className="text-xs">
+                              Low
+                            </Badge>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="space-y-3">
+                        <h4 className="font-semibold text-sm">
+                          Key Assumptions
+                        </h4>
+                        <div className="space-y-2 text-sm text-muted-foreground">
+                          <p>• Market growth rate: 15% annually</p>
+                          <p>• Customer retention: 85% average</p>
+                          <p>• Cost inflation: 3-5% per year</p>
+                          <p>• Technology adoption: 25% improvement</p>
+                          <div className="mt-3">
+                            <Link to="/risk-management">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="border-orange-200 text-orange-700"
+                              >
+                                <AlertTriangle className="h-4 w-4 mr-2" />
+                                Risk Management
+                              </Button>
+                            </Link>
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </CardContent>
                 </Card>
-              </LoadingOverlay>
-            </section>
-          </TabsContent>
+              </section>
+            </TabsContent>
 
-          <TabsContent value="planning" className="space-y-8">
-            {/* Scenario Planning */}
-            <section>
-              <LoadingOverlay
-                isLoading={isLoading}
-                loadingText="Updating scenarios..."
-              >
-                <ScenarioPlanningComponent scenarios={scenarios} />
-              </LoadingOverlay>
-            </section>
+            <TabsContent value="analytics" className="space-y-8">
+              {/* Performance Metrics & KPIs */}
+              <section>
+                <KPIDashboard kpis={kpis} />
+              </section>
 
-            {/* Risk & Assumption Analysis */}
-            <section>
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-lg flex items-center gap-2">
-                    <AlertTriangle className="h-5 w-5" />
-                    Risk & Assumption Analysis
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div className="space-y-3">
-                      <h4 className="font-semibold text-sm">Key Risks</h4>
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between p-2 border rounded">
-                          <span className="text-sm">Market Competition</span>
-                          <Badge variant="destructive" className="text-xs">
-                            High
-                          </Badge>
-                        </div>
-                        <div className="flex items-center justify-between p-2 border rounded">
-                          <span className="text-sm">
-                            Supply Chain Disruption
-                          </span>
-                          <Badge className="text-xs bg-economic-warning text-economic-warning-foreground">
-                            Medium
-                          </Badge>
-                        </div>
-                        <div className="flex items-center justify-between p-2 border rounded">
-                          <span className="text-sm">Regulatory Changes</span>
-                          <Badge variant="secondary" className="text-xs">
-                            Low
-                          </Badge>
-                        </div>
+              {/* Competitive & Market Context */}
+              <section>
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-lg flex items-center gap-2">
+                      <Target className="h-5 w-5" />
+                      Competitive & Market Context
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="space-y-4">
+                      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <Card className="p-4">
+                          <div className="space-y-2">
+                            <h4 className="font-medium text-sm">
+                              Market Share
+                            </h4>
+                            <div className="text-2xl font-bold">12.5%</div>
+                            <div className="text-xs text-muted-foreground">
+                              Target: 15%
+                            </div>
+                          </div>
+                        </Card>
+                        <Card className="p-4">
+                          <div className="space-y-2">
+                            <h4 className="font-medium text-sm">
+                              Competitive Position
+                            </h4>
+                            <div className="text-2xl font-bold">#3</div>
+                            <div className="text-xs text-muted-foreground">
+                              In target market
+                            </div>
+                          </div>
+                        </Card>
+                        <Card className="p-4">
+                          <div className="space-y-2">
+                            <h4 className="font-medium text-sm">
+                              Price Premium
+                            </h4>
+                            <div className="text-2xl font-bold">+8%</div>
+                            <div className="text-xs text-muted-foreground">
+                              vs. market average
+                            </div>
+                          </div>
+                        </Card>
+                      </div>
+                      <div className="mt-6 text-center">
+                        <Link to="/market-competitive-analysis">
+                          <Button
+                            variant="outline"
+                            className="border-blue-200 text-blue-700"
+                          >
+                            <BarChart3 className="h-4 w-4 mr-2" />
+                            Detailed Market Analysis
+                          </Button>
+                        </Link>
                       </div>
                     </div>
+                  </CardContent>
+                </Card>
+              </section>
+            </TabsContent>
 
-                    <div className="space-y-3">
-                      <h4 className="font-semibold text-sm">Key Assumptions</h4>
-                      <div className="space-y-2 text-sm text-muted-foreground">
-                        <p>• Market growth rate: 15% annually</p>
-                        <p>• Customer retention: 85% average</p>
-                        <p>• Cost inflation: 3-5% per year</p>
-                        <p>• Technology adoption: 25% improvement</p>
-                        <div className="mt-3">
-                          <Link to="/risk-management">
-                            <Button variant="outline" size="sm" className="border-orange-200 text-orange-700">
-                              <AlertTriangle className="h-4 w-4 mr-2" />
-                              Risk Management
-                            </Button>
-                          </Link>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </section>
-          </TabsContent>
+            <TabsContent value="documents" className="space-y-8">
+              <section>
+                <DocumentsSection />
+              </section>
+            </TabsContent>
+          </Tabs>
+        </main>
 
-          <TabsContent value="analytics" className="space-y-8">
-            {/* Performance Metrics & KPIs */}
-            <section>
-              <KPIDashboard kpis={kpis} />
-            </section>
-
-            {/* Competitive & Market Context */}
-            <section>
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-lg flex items-center gap-2">
-                    <Target className="h-5 w-5" />
-                    Competitive & Market Context
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-4">
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                      <Card className="p-4">
-                        <div className="space-y-2">
-                          <h4 className="font-medium text-sm">Market Share</h4>
-                          <div className="text-2xl font-bold">12.5%</div>
-                          <div className="text-xs text-muted-foreground">
-                            Target: 15%
-                          </div>
-                        </div>
-                      </Card>
-                      <Card className="p-4">
-                        <div className="space-y-2">
-                          <h4 className="font-medium text-sm">
-                            Competitive Position
-                          </h4>
-                          <div className="text-2xl font-bold">#3</div>
-                          <div className="text-xs text-muted-foreground">
-                            In target market
-                          </div>
-                        </div>
-                      </Card>
-                      <Card className="p-4">
-                        <div className="space-y-2">
-                          <h4 className="font-medium text-sm">Price Premium</h4>
-                          <div className="text-2xl font-bold">+8%</div>
-                          <div className="text-xs text-muted-foreground">
-                            vs. market average
-                          </div>
-                        </div>
-                      </Card>
-                    </div>
-                    <div className="mt-6 text-center">
-                      <Link to="/market-competitive-analysis">
-                        <Button variant="outline" className="border-blue-200 text-blue-700">
-                          <BarChart3 className="h-4 w-4 mr-2" />
-                          Detailed Market Analysis
-                        </Button>
-                      </Link>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </section>
-          </TabsContent>
-
-          <TabsContent value="documents" className="space-y-8">
-            <section>
-              <DocumentsSection />
-            </section>
-          </TabsContent>
-        </Tabs>
-      </main>
-
-      {/* Footer */}
-      <footer className="border-t bg-muted/30 mt-16">
-        <div className="container mx-auto px-4 py-6">
-          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-            <div className="flex items-center gap-4 text-sm text-muted-foreground">
-              <span>© 2024 Business Forecast Platform</span>
-              <span>•</span>
-              <span>Data updated every hour</span>
-            </div>
-            <div className="flex items-center gap-4 text-sm text-muted-foreground">
-              <span>
-                Models: Monte Carlo, Linear Regression, Scenario Analysis
-              </span>
+        {/* Footer */}
+        <footer className="border-t bg-muted/30 mt-16">
+          <div className="container mx-auto px-4 py-6">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                <span>© 2024 Business Forecast Platform</span>
+                <span>•</span>
+                <span>Data updated every hour</span>
+              </div>
+              <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                <span>
+                  Models: Monte Carlo, Linear Regression, Scenario Analysis
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-      </footer>
+        </footer>
       </div>
     </TooltipProvider>
   );

--- a/src/pages/BusinessForecast.tsx
+++ b/src/pages/BusinessForecast.tsx
@@ -17,8 +17,7 @@ import { ScenarioPlanningComponent } from "@/components/business/scenario-planni
 import { BusinessMetricsTable } from "@/components/business/business-metrics-table";
 import { FinancialLayout } from "@/components/business/financial-layout";
 import { DocumentsSection } from "@/components/business/documents-section";
-import { SummarySection } from "@/components/module/summary-section";
-import { RecommendationSection } from "@/components/module/recommendation-section";
+import { SummaryRecommendationSection } from "@/components/module/summary-recommendation-section";
 import {
   costStructure as mockCosts,
   cashFlowForecast as mockCashFlow,
@@ -149,10 +148,9 @@ const BusinessForecast = () => {
         {/* Main Content Tabs */}
         <Tabs defaultValue="overview" className="space-y-6">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <TabsList className="grid grid-cols-9 w-full sm:w-auto">
+            <TabsList className="grid grid-cols-8 w-full sm:w-auto">
               <TabsTrigger value="overview">Overview</TabsTrigger>
-              <TabsTrigger value="summary">Summary</TabsTrigger>
-              <TabsTrigger value="recommendations">Recommendations</TabsTrigger>
+              <TabsTrigger value="summary-recommendation">Summary & Recommendation</TabsTrigger>
               <TabsTrigger value="tables">Tables</TabsTrigger>
               <TabsTrigger value="revenue">Revenue</TabsTrigger>
               <TabsTrigger value="costs">Costs</TabsTrigger>
@@ -224,10 +222,10 @@ const BusinessForecast = () => {
             </section>
           </TabsContent>
 
-          <TabsContent value="summary" className="space-y-8">
-            <SummarySection
-              title="Business Forecast Summary"
-              description="Executive summary with key metrics and insights"
+          <TabsContent value="summary-recommendation" className="space-y-8">
+            <SummaryRecommendationSection
+              summaryTitle="Business Forecast Summary"
+              summaryDescription="Executive summary with key metrics and insights"
               summaryText={`1. REVENUE OVERVIEW
 Current annual revenue target is set at $13.7M with ${customerProfiles.length} distinct customer segments identified. The forecast includes ${scenarios.length} scenario models to cover conservative, base, and aggressive growth cases.
 
@@ -242,7 +240,7 @@ The forecast employs Monte Carlo simulations, linear regression analysis, and sc
 
 5. NEXT QUARTER OUTLOOK
 Q1 2025 focuses on foundation building, with emphasis on customer retention and operational efficiency improvements. Expected growth rate aligns with market expansion strategy.`}
-              metrics={[
+              summaryMetrics={[
                 {
                   index: 1,
                   title: "Annual Revenue Target",
@@ -268,13 +266,8 @@ Q1 2025 focuses on foundation building, with emphasis on customer retention and 
                   insight: "Planning scenarios for different market conditions",
                 },
               ]}
-            />
-          </TabsContent>
-
-          <TabsContent value="recommendations" className="space-y-8">
-            <RecommendationSection
-              title="Business Forecast Recommendations"
-              description="Strategic recommendations and action items based on forecast analysis"
+              recommendationTitle="Business Forecast Recommendations"
+              recommendationDescription="Strategic recommendations and action items based on forecast analysis"
               recommendationText={`1. REVENUE OPTIMIZATION
 Prioritize high-margin customer segments that show strongest growth potential. Consider dynamic pricing strategies for products with high elasticity. Implement customer lifetime value modeling to focus acquisition and retention efforts on most valuable segments.
 

--- a/src/pages/BusinessForecast.tsx
+++ b/src/pages/BusinessForecast.tsx
@@ -149,8 +149,10 @@ const BusinessForecast = () => {
         {/* Main Content Tabs */}
         <Tabs defaultValue="overview" className="space-y-6">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <TabsList className="grid grid-cols-7 w-full sm:w-auto">
+            <TabsList className="grid grid-cols-9 w-full sm:w-auto">
               <TabsTrigger value="overview">Overview</TabsTrigger>
+              <TabsTrigger value="summary">Summary</TabsTrigger>
+              <TabsTrigger value="recommendations">Recommendations</TabsTrigger>
               <TabsTrigger value="tables">Tables</TabsTrigger>
               <TabsTrigger value="revenue">Revenue</TabsTrigger>
               <TabsTrigger value="costs">Costs</TabsTrigger>

--- a/src/pages/FinancialAdvisory.tsx
+++ b/src/pages/FinancialAdvisory.tsx
@@ -356,6 +356,142 @@ export default function FinancialAdvisory() {
             />
           </TabsContent>
 
+          <TabsContent value="summary" className="space-y-8">
+            <SummarySection
+              title="Financial Advisory Summary"
+              description="Executive summary of financial position and key metrics"
+              summaryText={`1. FINANCIAL POSITION OVERVIEW
+The organization maintains a strong financial position with healthy liquidity and profitability metrics. Cash flow projections show positive trends with adequate reserves to support operational needs and strategic investments.
+
+2. BUDGET PERFORMANCE
+Current budget execution shows ${budgetForecasts.length} active forecasts tracking within acceptable variance ranges. Actual spending aligns with planning assumptions, indicating strong cost controls and forecast accuracy.
+
+3. CASH FLOW MANAGEMENT
+Monthly cash flow projections indicate stable operational liquidity with ${liquidityMetrics.length} key metrics within target parameters. Working capital management is efficient with appropriate levels of inventory and receivables.
+
+4. FINANCIAL RISKS
+${riskAssessments.length} financial risks have been identified and are being actively monitored. Mitigation strategies are in place for material risks. Scenario analysis shows resilience across multiple stress test scenarios.
+
+5. STRATEGIC FINANCIAL INITIATIVES
+Performance drivers analysis indicates key areas for financial optimization. Recommended initiatives focus on improving profitability, optimizing capital deployment, and enhancing shareholder value.`}
+              metrics={[
+                {
+                  index: 1,
+                  title: "Budget Forecasts",
+                  value: budgetForecasts.length,
+                  insight: "Active financial forecasts being tracked",
+                },
+                {
+                  index: 2,
+                  title: "Cash Flow Projections",
+                  value: cashFlowProjections.length,
+                  insight: "Monthly cash flow forecasts available",
+                },
+                {
+                  index: 3,
+                  title: "Scenario Tests",
+                  value: scenarioTests.length,
+                  insight: "Financial scenario models for planning",
+                },
+                {
+                  index: 4,
+                  title: "Risk Assessments",
+                  value: riskAssessments.length,
+                  insight: "Financial risks under active review",
+                },
+              ]}
+            />
+          </TabsContent>
+
+          <TabsContent value="recommendations" className="space-y-8">
+            <RecommendationSection
+              title="Financial Advisory Recommendations"
+              description="Strategic recommendations for financial optimization and risk management"
+              recommendationText={`1. BUDGET OPTIMIZATION
+Implement zero-based budgeting approach for discretionary spending categories. Establish monthly variance analysis with accountability for budget managers. Consider rolling forecasts to improve planning accuracy and flexibility.
+
+2. CASH FLOW MANAGEMENT
+Implement daily cash position monitoring and forecasting. Optimize working capital through improved payables management and receivables collection. Establish cash reserve policy to ensure adequate liquidity buffers.
+
+3. FINANCIAL PLANNING
+Develop integrated financial plan linking operational and strategic objectives. Implement quarterly business reviews to track progress and adjust plans. Build scenario planning capability for strategic decision-making.
+
+4. RISK MANAGEMENT
+Implement enhanced financial risk monitoring and reporting. Develop mitigation strategies for material financial risks. Establish governance process for financial risk decisions.
+
+5. PERFORMANCE MANAGEMENT
+Implement comprehensive KPI dashboard for financial performance tracking. Establish targets and accountability for key financial drivers. Conduct regular variance analysis with root cause assessment.`}
+              actionItems={[
+                {
+                  index: 1,
+                  title: "Enhanced Budget Forecasting",
+                  description:
+                    "Implement advanced budgeting system with rolling forecasts and monthly variance tracking",
+                  priority: "high",
+                  timeline: "Q1 2025",
+                },
+                {
+                  index: 2,
+                  title: "Cash Flow Optimization Program",
+                  description:
+                    "Launch comprehensive working capital optimization initiative to improve cash conversion and liquidity",
+                  priority: "high",
+                  timeline: "Q1 2025",
+                },
+                {
+                  index: 3,
+                  title: "Financial Risk Framework",
+                  description:
+                    "Develop and implement financial risk management framework with regular monitoring and reporting",
+                  priority: "medium",
+                  timeline: "Q2 2025",
+                },
+                {
+                  index: 4,
+                  title: "Performance Dashboard Implementation",
+                  description:
+                    "Build comprehensive financial performance dashboard with real-time KPI tracking and alerts",
+                  priority: "medium",
+                  timeline: "Q2 2025",
+                },
+                {
+                  index: 5,
+                  title: "Strategic Planning Process",
+                  description:
+                    "Establish integrated strategic planning process linking financial and operational objectives",
+                  priority: "low",
+                  timeline: "Q2-Q3 2025",
+                },
+              ]}
+              nextSteps={[
+                {
+                  index: 1,
+                  step: "Review and validate all budget assumptions and forecasts",
+                  owner: "Finance Team",
+                  dueDate: "End of Week 1",
+                },
+                {
+                  index: 2,
+                  step: "Conduct financial risk assessment and prioritize risks",
+                  owner: "Risk Management Team",
+                  dueDate: "End of Week 2",
+                },
+                {
+                  index: 3,
+                  step: "Develop financial recommendations for executive review",
+                  owner: "CFO",
+                  dueDate: "Mid-Month",
+                },
+                {
+                  index: 4,
+                  step: "Establish monthly financial review cadence",
+                  owner: "Controller",
+                  dueDate: "Ongoing",
+                },
+              ]}
+            />
+          </TabsContent>
+
           <TabsContent value="cash-flow" className="space-y-6">
             <CashFlowPlanning
               cashFlowProjections={cashFlowProjections}

--- a/src/pages/FinancialAdvisory.tsx
+++ b/src/pages/FinancialAdvisory.tsx
@@ -29,6 +29,8 @@ import { ScenarioTesting } from "../components/financial/scenario-testing";
 import { RiskAssessmentComponent } from "../components/financial/risk-assessment";
 import { PerformanceDrivers } from "../components/financial/performance-drivers";
 import { AdvisoryInsights } from "../components/financial/advisory-insights";
+import { SummarySection } from "../components/module/summary-section";
+import { RecommendationSection } from "../components/module/recommendation-section";
 import {
   Loader2,
   Calculator,

--- a/src/pages/FinancialAdvisory.tsx
+++ b/src/pages/FinancialAdvisory.tsx
@@ -264,7 +264,7 @@ export default function FinancialAdvisory() {
           onValueChange={setActiveTab}
           className="space-y-6"
         >
-          <TabsList className="grid w-full grid-cols-7 bg-white shadow-sm">
+          <TabsList className="grid w-full grid-cols-9 bg-white shadow-sm">
             <TabsTrigger
               value="strategic-budgeting"
               className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
@@ -272,6 +272,24 @@ export default function FinancialAdvisory() {
               <TrendingUp className="w-4 h-4" />
               <span className="hidden sm:inline">Strategic Budgeting</span>
               <span className="sm:hidden">Budgeting</span>
+            </TabsTrigger>
+
+            <TabsTrigger
+              value="summary"
+              className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+            >
+              <BarChart3 className="w-4 h-4" />
+              <span className="hidden sm:inline">Summary</span>
+              <span className="sm:hidden">Summary</span>
+            </TabsTrigger>
+
+            <TabsTrigger
+              value="recommendations"
+              className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+            >
+              <Target className="w-4 h-4" />
+              <span className="hidden sm:inline">Recommendations</span>
+              <span className="sm:hidden">Rec.</span>
             </TabsTrigger>
 
             <TabsTrigger

--- a/src/pages/FinancialAdvisory.tsx
+++ b/src/pages/FinancialAdvisory.tsx
@@ -100,267 +100,294 @@ export default function FinancialAdvisory() {
   return (
     <TooltipProvider>
       <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
-      {/* Header */}
-      <header className="bg-white/60 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <div className="flex flex-col gap-4">
-            <div>
-              <div className="flex items-center gap-3">
-                <div className="flex items-center justify-center w-10 h-10 bg-blue-600 rounded-xl text-white">
-                  <Calculator className="w-5 h-5" />
-                </div>
-                <div>
-                  <h1 className="text-2xl font-bold text-gray-900 tracking-tight">
-                    Financial Advisory & Planning
-                  </h1>
-                  <p className="text-sm text-gray-600">
-                    Strategic budgeting, cash flow management, and advisory
-                    insights
-                  </p>
+        {/* Header */}
+        <header className="bg-white/60 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-50">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <div className="flex flex-col gap-4">
+              <div>
+                <div className="flex items-center gap-3">
+                  <div className="flex items-center justify-center w-10 h-10 bg-blue-600 rounded-xl text-white">
+                    <Calculator className="w-5 h-5" />
+                  </div>
+                  <div>
+                    <h1 className="text-2xl font-bold text-gray-900 tracking-tight">
+                      Financial Advisory & Planning
+                    </h1>
+                    <p className="text-sm text-gray-600">
+                      Strategic budgeting, cash flow management, and advisory
+                      insights
+                    </p>
+                  </div>
                 </div>
               </div>
-            </div>
 
-            <div className="flex items-center gap-3">
-              <ModuleNavigation />
-              <ConnectionStatus lastUpdated={lastUpdated} />
+              <div className="flex items-center gap-3">
+                <ModuleNavigation />
+                <ConnectionStatus lastUpdated={lastUpdated} />
 
-              {/* Notifications Tab */}
-              <Popover open={notificationsOpen} onOpenChange={setNotificationsOpen}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="flex items-center gap-2 relative"
-                      >
-                        <Bell className="h-4 w-4" />
-                        <span className="hidden sm:inline">Notifications</span>
-                        <Badge
-                          variant="destructive"
-                          className="absolute -top-2 -right-2 px-1.5 py-0.5 text-xs min-w-5 h-5 flex items-center justify-center rounded-full"
+                {/* Notifications Tab */}
+                <Popover
+                  open={notificationsOpen}
+                  onOpenChange={setNotificationsOpen}
+                >
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="flex items-center gap-2 relative"
                         >
-                          2
-                        </Badge>
-                      </Button>
-                    </PopoverTrigger>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>View notifications and alerts</p>
-                  </TooltipContent>
-                </Tooltip>
-                <PopoverContent className="w-80" align="end">
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <h4 className="font-semibold">Notifications</h4>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => setNotificationsOpen(false)}
-                      >
-                        <X className="h-4 w-4" />
-                      </Button>
-                    </div>
-                    <div className="space-y-3">
-                      <div className="p-3 rounded-lg border bg-card">
-                        <div className="flex items-start gap-3">
-                          <Calculator className="h-4 w-4 text-blue-500 mt-0.5 flex-shrink-0" />
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm font-medium">Budget Alert</p>
-                            <p className="text-xs text-muted-foreground">Q2 budget variance exceeds threshold</p>
-                            <p className="text-xs text-muted-foreground mt-1">15 minutes ago</p>
+                          <Bell className="h-4 w-4" />
+                          <span className="hidden sm:inline">
+                            Notifications
+                          </span>
+                          <Badge
+                            variant="destructive"
+                            className="absolute -top-2 -right-2 px-1.5 py-0.5 text-xs min-w-5 h-5 flex items-center justify-center rounded-full"
+                          >
+                            2
+                          </Badge>
+                        </Button>
+                      </PopoverTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>View notifications and alerts</p>
+                    </TooltipContent>
+                  </Tooltip>
+                  <PopoverContent className="w-80" align="end">
+                    <div className="space-y-4">
+                      <div className="flex items-center justify-between">
+                        <h4 className="font-semibold">Notifications</h4>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setNotificationsOpen(false)}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                      <div className="space-y-3">
+                        <div className="p-3 rounded-lg border bg-card">
+                          <div className="flex items-start gap-3">
+                            <Calculator className="h-4 w-4 text-blue-500 mt-0.5 flex-shrink-0" />
+                            <div className="flex-1 min-w-0">
+                              <p className="text-sm font-medium">
+                                Budget Alert
+                              </p>
+                              <p className="text-xs text-muted-foreground">
+                                Q2 budget variance exceeds threshold
+                              </p>
+                              <p className="text-xs text-muted-foreground mt-1">
+                                15 minutes ago
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="p-3 rounded-lg border bg-card">
+                          <div className="flex items-start gap-3">
+                            <TrendingUp className="h-4 w-4 text-green-500 mt-0.5 flex-shrink-0" />
+                            <div className="flex-1 min-w-0">
+                              <p className="text-sm font-medium">
+                                Cash Flow Update
+                              </p>
+                              <p className="text-xs text-muted-foreground">
+                                Monthly projections updated successfully
+                              </p>
+                              <p className="text-xs text-muted-foreground mt-1">
+                                1 hour ago
+                              </p>
+                            </div>
                           </div>
                         </div>
                       </div>
-                      <div className="p-3 rounded-lg border bg-card">
-                        <div className="flex items-start gap-3">
-                          <TrendingUp className="h-4 w-4 text-green-500 mt-0.5 flex-shrink-0" />
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm font-medium">Cash Flow Update</p>
-                            <p className="text-xs text-muted-foreground">Monthly projections updated successfully</p>
-                            <p className="text-xs text-muted-foreground mt-1">1 hour ago</p>
-                          </div>
-                        </div>
-                      </div>
+                      <Link to="/notifications">
+                        <Button variant="outline" className="w-full" size="sm">
+                          View All Notifications
+                        </Button>
+                      </Link>
                     </div>
-                    <Link to="/notifications">
-                      <Button variant="outline" className="w-full" size="sm">
-                        View All Notifications
-                      </Button>
-                    </Link>
-                  </div>
-                </PopoverContent>
-              </Popover>
+                  </PopoverContent>
+                </Popover>
 
-              {/* Ideas Tab */}
-              <Popover open={ideasOpen} onOpenChange={setIdeasOpen}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="flex items-center gap-2"
-                      >
-                        <Lightbulb className="h-4 w-4" />
-                        <span className="hidden sm:inline">Ideas</span>
-                      </Button>
-                    </PopoverTrigger>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>AI-powered financial insights</p>
-                  </TooltipContent>
-                </Tooltip>
-                <PopoverContent className="w-80" align="end">
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <h4 className="font-semibold">Financial Ideas</h4>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => setIdeasOpen(false)}
-                      >
-                        <X className="h-4 w-4" />
-                      </Button>
-                    </div>
-                    <div className="space-y-3">
-                      <div className="p-3 rounded-lg border bg-card">
-                        <div className="flex items-start gap-3">
-                          <Lightbulb className="h-4 w-4 text-yellow-500 mt-0.5 flex-shrink-0" />
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm font-medium">Budget Optimization</p>
-                            <p className="text-xs text-muted-foreground">Reallocate 8% from marketing to R&D for better ROI</p>
+                {/* Ideas Tab */}
+                <Popover open={ideasOpen} onOpenChange={setIdeasOpen}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="flex items-center gap-2"
+                        >
+                          <Lightbulb className="h-4 w-4" />
+                          <span className="hidden sm:inline">Ideas</span>
+                        </Button>
+                      </PopoverTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>AI-powered financial insights</p>
+                    </TooltipContent>
+                  </Tooltip>
+                  <PopoverContent className="w-80" align="end">
+                    <div className="space-y-4">
+                      <div className="flex items-center justify-between">
+                        <h4 className="font-semibold">Financial Ideas</h4>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setIdeasOpen(false)}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                      <div className="space-y-3">
+                        <div className="p-3 rounded-lg border bg-card">
+                          <div className="flex items-start gap-3">
+                            <Lightbulb className="h-4 w-4 text-yellow-500 mt-0.5 flex-shrink-0" />
+                            <div className="flex-1 min-w-0">
+                              <p className="text-sm font-medium">
+                                Budget Optimization
+                              </p>
+                              <p className="text-xs text-muted-foreground">
+                                Reallocate 8% from marketing to R&D for better
+                                ROI
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="p-3 rounded-lg border bg-card">
+                          <div className="flex items-start gap-3">
+                            <Target className="h-4 w-4 text-green-500 mt-0.5 flex-shrink-0" />
+                            <div className="flex-1 min-w-0">
+                              <p className="text-sm font-medium">
+                                Cash Flow Strategy
+                              </p>
+                              <p className="text-xs text-muted-foreground">
+                                Consider negotiating 45-day payment terms with
+                                suppliers
+                              </p>
+                            </div>
                           </div>
                         </div>
                       </div>
-                      <div className="p-3 rounded-lg border bg-card">
-                        <div className="flex items-start gap-3">
-                          <Target className="h-4 w-4 text-green-500 mt-0.5 flex-shrink-0" />
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm font-medium">Cash Flow Strategy</p>
-                            <p className="text-xs text-muted-foreground">Consider negotiating 45-day payment terms with suppliers</p>
-                          </div>
-                        </div>
-                      </div>
+                      <Link to="/ai-insights">
+                        <Button variant="outline" className="w-full" size="sm">
+                          Generate More Ideas
+                        </Button>
+                      </Link>
                     </div>
-                    <Link to="/ai-insights">
-                      <Button variant="outline" className="w-full" size="sm">
-                        Generate More Ideas
-                      </Button>
-                    </Link>
-                  </div>
-                </PopoverContent>
-              </Popover>
+                  </PopoverContent>
+                </Popover>
+              </div>
             </div>
           </div>
-        </div>
-      </header>
+        </header>
 
-      {/* Main Content */}
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <Tabs
-          value={activeTab}
-          onValueChange={setActiveTab}
-          className="space-y-6"
-        >
-          <TabsList className="grid w-full grid-cols-9 bg-white shadow-sm">
-            <TabsTrigger
-              value="strategic-budgeting"
-              className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
-            >
-              <TrendingUp className="w-4 h-4" />
-              <span className="hidden sm:inline">Strategic Budgeting</span>
-              <span className="sm:hidden">Budgeting</span>
-            </TabsTrigger>
+        {/* Main Content */}
+        <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <Tabs
+            value={activeTab}
+            onValueChange={setActiveTab}
+            className="space-y-6"
+          >
+            <TabsList className="grid w-full grid-cols-9 bg-white shadow-sm">
+              <TabsTrigger
+                value="strategic-budgeting"
+                className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+              >
+                <TrendingUp className="w-4 h-4" />
+                <span className="hidden sm:inline">Strategic Budgeting</span>
+                <span className="sm:hidden">Budgeting</span>
+              </TabsTrigger>
 
-            <TabsTrigger
-              value="summary"
-              className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
-            >
-              <BarChart3 className="w-4 h-4" />
-              <span className="hidden sm:inline">Summary</span>
-              <span className="sm:hidden">Summary</span>
-            </TabsTrigger>
+              <TabsTrigger
+                value="summary"
+                className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+              >
+                <BarChart3 className="w-4 h-4" />
+                <span className="hidden sm:inline">Summary</span>
+                <span className="sm:hidden">Summary</span>
+              </TabsTrigger>
 
-            <TabsTrigger
-              value="recommendations"
-              className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
-            >
-              <Target className="w-4 h-4" />
-              <span className="hidden sm:inline">Recommendations</span>
-              <span className="sm:hidden">Rec.</span>
-            </TabsTrigger>
+              <TabsTrigger
+                value="recommendations"
+                className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+              >
+                <Target className="w-4 h-4" />
+                <span className="hidden sm:inline">Recommendations</span>
+                <span className="sm:hidden">Rec.</span>
+              </TabsTrigger>
 
-            <TabsTrigger
-              value="cash-flow"
-              className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
-            >
-              <Target className="w-4 h-4" />
-              <span className="hidden sm:inline">Cash Flow</span>
-              <span className="sm:hidden">Cash</span>
-            </TabsTrigger>
+              <TabsTrigger
+                value="cash-flow"
+                className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+              >
+                <Target className="w-4 h-4" />
+                <span className="hidden sm:inline">Cash Flow</span>
+                <span className="sm:hidden">Cash</span>
+              </TabsTrigger>
 
-            <TabsTrigger
-              value="budget-validation"
-              className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
-            >
-              <BarChart3 className="w-4 h-4" />
-              <span className="hidden sm:inline">Validation</span>
-              <span className="sm:hidden">Validation</span>
-            </TabsTrigger>
+              <TabsTrigger
+                value="budget-validation"
+                className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+              >
+                <BarChart3 className="w-4 h-4" />
+                <span className="hidden sm:inline">Validation</span>
+                <span className="sm:hidden">Validation</span>
+              </TabsTrigger>
 
-            <TabsTrigger
-              value="scenario-testing"
-              className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
-            >
-              <Calculator className="w-4 h-4" />
-              <span className="hidden sm:inline">Scenarios</span>
-              <span className="sm:hidden">Scenarios</span>
-            </TabsTrigger>
+              <TabsTrigger
+                value="scenario-testing"
+                className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+              >
+                <Calculator className="w-4 h-4" />
+                <span className="hidden sm:inline">Scenarios</span>
+                <span className="sm:hidden">Scenarios</span>
+              </TabsTrigger>
 
-            <TabsTrigger
-              value="risk-assessment"
-              className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
-            >
-              <Shield className="w-4 h-4" />
-              <span className="hidden sm:inline">Risk</span>
-              <span className="sm:hidden">Risk</span>
-            </TabsTrigger>
+              <TabsTrigger
+                value="risk-assessment"
+                className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+              >
+                <Shield className="w-4 h-4" />
+                <span className="hidden sm:inline">Risk</span>
+                <span className="sm:hidden">Risk</span>
+              </TabsTrigger>
 
-            <TabsTrigger
-              value="performance-drivers"
-              className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
-            >
-              <Target className="w-4 h-4" />
-              <span className="hidden sm:inline">Performance</span>
-              <span className="sm:hidden">KPIs</span>
-            </TabsTrigger>
+              <TabsTrigger
+                value="performance-drivers"
+                className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+              >
+                <Target className="w-4 h-4" />
+                <span className="hidden sm:inline">Performance</span>
+                <span className="sm:hidden">KPIs</span>
+              </TabsTrigger>
 
-            <TabsTrigger
-              value="advisory-insights"
-              className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
-            >
-              <Lightbulb className="w-4 h-4" />
-              <span className="hidden sm:inline">Insights</span>
-              <span className="sm:hidden">Insights</span>
-            </TabsTrigger>
-          </TabsList>
+              <TabsTrigger
+                value="advisory-insights"
+                className="flex items-center gap-2 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+              >
+                <Lightbulb className="w-4 h-4" />
+                <span className="hidden sm:inline">Insights</span>
+                <span className="sm:hidden">Insights</span>
+              </TabsTrigger>
+            </TabsList>
 
-          <TabsContent value="strategic-budgeting" className="space-y-6">
-            <StrategicBudgeting
-              budgetForecasts={budgetForecasts}
-              budgetAssumptions={budgetAssumptions}
-              onCreateForecast={createBudgetForecast}
-              onUpdateAssumption={updateBudgetAssumption}
-            />
-          </TabsContent>
+            <TabsContent value="strategic-budgeting" className="space-y-6">
+              <StrategicBudgeting
+                budgetForecasts={budgetForecasts}
+                budgetAssumptions={budgetAssumptions}
+                onCreateForecast={createBudgetForecast}
+                onUpdateAssumption={updateBudgetAssumption}
+              />
+            </TabsContent>
 
-          <TabsContent value="summary" className="space-y-8">
-            <SummarySection
-              title="Financial Advisory Summary"
-              description="Executive summary of financial position and key metrics"
-              summaryText={`1. FINANCIAL POSITION OVERVIEW
+            <TabsContent value="summary" className="space-y-8">
+              <SummarySection
+                title="Financial Advisory Summary"
+                description="Executive summary of financial position and key metrics"
+                summaryText={`1. FINANCIAL POSITION OVERVIEW
 The organization maintains a strong financial position with healthy liquidity and profitability metrics. Cash flow projections show positive trends with adequate reserves to support operational needs and strategic investments.
 
 2. BUDGET PERFORMANCE
@@ -374,40 +401,40 @@ ${riskAssessments.length} financial risks have been identified and are being act
 
 5. STRATEGIC FINANCIAL INITIATIVES
 Performance drivers analysis indicates key areas for financial optimization. Recommended initiatives focus on improving profitability, optimizing capital deployment, and enhancing shareholder value.`}
-              metrics={[
-                {
-                  index: 1,
-                  title: "Budget Forecasts",
-                  value: budgetForecasts.length,
-                  insight: "Active financial forecasts being tracked",
-                },
-                {
-                  index: 2,
-                  title: "Cash Flow Projections",
-                  value: cashFlowProjections.length,
-                  insight: "Monthly cash flow forecasts available",
-                },
-                {
-                  index: 3,
-                  title: "Scenario Tests",
-                  value: scenarioTests.length,
-                  insight: "Financial scenario models for planning",
-                },
-                {
-                  index: 4,
-                  title: "Risk Assessments",
-                  value: riskAssessments.length,
-                  insight: "Financial risks under active review",
-                },
-              ]}
-            />
-          </TabsContent>
+                metrics={[
+                  {
+                    index: 1,
+                    title: "Budget Forecasts",
+                    value: budgetForecasts.length,
+                    insight: "Active financial forecasts being tracked",
+                  },
+                  {
+                    index: 2,
+                    title: "Cash Flow Projections",
+                    value: cashFlowProjections.length,
+                    insight: "Monthly cash flow forecasts available",
+                  },
+                  {
+                    index: 3,
+                    title: "Scenario Tests",
+                    value: scenarioTests.length,
+                    insight: "Financial scenario models for planning",
+                  },
+                  {
+                    index: 4,
+                    title: "Risk Assessments",
+                    value: riskAssessments.length,
+                    insight: "Financial risks under active review",
+                  },
+                ]}
+              />
+            </TabsContent>
 
-          <TabsContent value="recommendations" className="space-y-8">
-            <RecommendationSection
-              title="Financial Advisory Recommendations"
-              description="Strategic recommendations for financial optimization and risk management"
-              recommendationText={`1. BUDGET OPTIMIZATION
+            <TabsContent value="recommendations" className="space-y-8">
+              <RecommendationSection
+                title="Financial Advisory Recommendations"
+                description="Strategic recommendations for financial optimization and risk management"
+                recommendationText={`1. BUDGET OPTIMIZATION
 Implement zero-based budgeting approach for discretionary spending categories. Establish monthly variance analysis with accountability for budget managers. Consider rolling forecasts to improve planning accuracy and flexibility.
 
 2. CASH FLOW MANAGEMENT
@@ -421,115 +448,115 @@ Implement enhanced financial risk monitoring and reporting. Develop mitigation s
 
 5. PERFORMANCE MANAGEMENT
 Implement comprehensive KPI dashboard for financial performance tracking. Establish targets and accountability for key financial drivers. Conduct regular variance analysis with root cause assessment.`}
-              actionItems={[
-                {
-                  index: 1,
-                  title: "Enhanced Budget Forecasting",
-                  description:
-                    "Implement advanced budgeting system with rolling forecasts and monthly variance tracking",
-                  priority: "high",
-                  timeline: "Q1 2025",
-                },
-                {
-                  index: 2,
-                  title: "Cash Flow Optimization Program",
-                  description:
-                    "Launch comprehensive working capital optimization initiative to improve cash conversion and liquidity",
-                  priority: "high",
-                  timeline: "Q1 2025",
-                },
-                {
-                  index: 3,
-                  title: "Financial Risk Framework",
-                  description:
-                    "Develop and implement financial risk management framework with regular monitoring and reporting",
-                  priority: "medium",
-                  timeline: "Q2 2025",
-                },
-                {
-                  index: 4,
-                  title: "Performance Dashboard Implementation",
-                  description:
-                    "Build comprehensive financial performance dashboard with real-time KPI tracking and alerts",
-                  priority: "medium",
-                  timeline: "Q2 2025",
-                },
-                {
-                  index: 5,
-                  title: "Strategic Planning Process",
-                  description:
-                    "Establish integrated strategic planning process linking financial and operational objectives",
-                  priority: "low",
-                  timeline: "Q2-Q3 2025",
-                },
-              ]}
-              nextSteps={[
-                {
-                  index: 1,
-                  step: "Review and validate all budget assumptions and forecasts",
-                  owner: "Finance Team",
-                  dueDate: "End of Week 1",
-                },
-                {
-                  index: 2,
-                  step: "Conduct financial risk assessment and prioritize risks",
-                  owner: "Risk Management Team",
-                  dueDate: "End of Week 2",
-                },
-                {
-                  index: 3,
-                  step: "Develop financial recommendations for executive review",
-                  owner: "CFO",
-                  dueDate: "Mid-Month",
-                },
-                {
-                  index: 4,
-                  step: "Establish monthly financial review cadence",
-                  owner: "Controller",
-                  dueDate: "Ongoing",
-                },
-              ]}
-            />
-          </TabsContent>
+                actionItems={[
+                  {
+                    index: 1,
+                    title: "Enhanced Budget Forecasting",
+                    description:
+                      "Implement advanced budgeting system with rolling forecasts and monthly variance tracking",
+                    priority: "high",
+                    timeline: "Q1 2025",
+                  },
+                  {
+                    index: 2,
+                    title: "Cash Flow Optimization Program",
+                    description:
+                      "Launch comprehensive working capital optimization initiative to improve cash conversion and liquidity",
+                    priority: "high",
+                    timeline: "Q1 2025",
+                  },
+                  {
+                    index: 3,
+                    title: "Financial Risk Framework",
+                    description:
+                      "Develop and implement financial risk management framework with regular monitoring and reporting",
+                    priority: "medium",
+                    timeline: "Q2 2025",
+                  },
+                  {
+                    index: 4,
+                    title: "Performance Dashboard Implementation",
+                    description:
+                      "Build comprehensive financial performance dashboard with real-time KPI tracking and alerts",
+                    priority: "medium",
+                    timeline: "Q2 2025",
+                  },
+                  {
+                    index: 5,
+                    title: "Strategic Planning Process",
+                    description:
+                      "Establish integrated strategic planning process linking financial and operational objectives",
+                    priority: "low",
+                    timeline: "Q2-Q3 2025",
+                  },
+                ]}
+                nextSteps={[
+                  {
+                    index: 1,
+                    step: "Review and validate all budget assumptions and forecasts",
+                    owner: "Finance Team",
+                    dueDate: "End of Week 1",
+                  },
+                  {
+                    index: 2,
+                    step: "Conduct financial risk assessment and prioritize risks",
+                    owner: "Risk Management Team",
+                    dueDate: "End of Week 2",
+                  },
+                  {
+                    index: 3,
+                    step: "Develop financial recommendations for executive review",
+                    owner: "CFO",
+                    dueDate: "Mid-Month",
+                  },
+                  {
+                    index: 4,
+                    step: "Establish monthly financial review cadence",
+                    owner: "Controller",
+                    dueDate: "Ongoing",
+                  },
+                ]}
+              />
+            </TabsContent>
 
-          <TabsContent value="cash-flow" className="space-y-6">
-            <CashFlowPlanning
-              cashFlowProjections={cashFlowProjections}
-              liquidityMetrics={liquidityMetrics}
-              onAddProjection={addCashFlowProjection}
-            />
-          </TabsContent>
+            <TabsContent value="cash-flow" className="space-y-6">
+              <CashFlowPlanning
+                cashFlowProjections={cashFlowProjections}
+                liquidityMetrics={liquidityMetrics}
+                onAddProjection={addCashFlowProjection}
+              />
+            </TabsContent>
 
-          <TabsContent value="budget-validation" className="space-y-6">
-            <BudgetValidation budgetForecasts={budgetForecasts} />
-          </TabsContent>
+            <TabsContent value="budget-validation" className="space-y-6">
+              <BudgetValidation budgetForecasts={budgetForecasts} />
+            </TabsContent>
 
-          <TabsContent value="scenario-testing" className="space-y-6">
-            <ScenarioTesting
-              scenarioTests={scenarioTests}
-              onRunScenario={runScenarioTest}
-            />
-          </TabsContent>
+            <TabsContent value="scenario-testing" className="space-y-6">
+              <ScenarioTesting
+                scenarioTests={scenarioTests}
+                onRunScenario={runScenarioTest}
+              />
+            </TabsContent>
 
-          <TabsContent value="risk-assessment" className="space-y-6">
-            <RiskAssessmentComponent
-              riskAssessments={riskAssessments}
-              onUpdateRiskStatus={updateRiskStatus}
-            />
-          </TabsContent>
+            <TabsContent value="risk-assessment" className="space-y-6">
+              <RiskAssessmentComponent
+                riskAssessments={riskAssessments}
+                onUpdateRiskStatus={updateRiskStatus}
+              />
+            </TabsContent>
 
-          <TabsContent value="performance-drivers" className="space-y-6">
-            <PerformanceDrivers performanceDrivers={performanceDrivers} />
-          </TabsContent>
+            <TabsContent value="performance-drivers" className="space-y-6">
+              <PerformanceDrivers performanceDrivers={performanceDrivers} />
+            </TabsContent>
 
-          <TabsContent value="advisory-insights" className="space-y-6">
-            <AdvisoryInsights
-              advisoryInsights={advisoryInsights}
-              onUpdateInsightStatus={updateInsightStatus}
-            />
-          </TabsContent>
-        </Tabs>
-      </main>
+            <TabsContent value="advisory-insights" className="space-y-6">
+              <AdvisoryInsights
+                advisoryInsights={advisoryInsights}
+                onUpdateInsightStatus={updateInsightStatus}
+              />
+            </TabsContent>
+          </Tabs>
+        </main>
       </div>
     </TooltipProvider>
   );

--- a/src/pages/InventorySupplyChain.tsx
+++ b/src/pages/InventorySupplyChain.tsx
@@ -22,6 +22,8 @@ import { ProcurementTracking } from "@/components/supply-chain/procurement-track
 import { ProductionPlanning } from "@/components/supply-chain/production-planning";
 import { SupplyChainAnalytics } from "@/components/supply-chain/supply-chain-analytics";
 import ModuleHeader from "@/components/ui/module-header";
+import { SummarySection } from "@/components/module/summary-section";
+import { RecommendationSection } from "@/components/module/recommendation-section";
 import {
   Package,
   TrendingUp,

--- a/src/pages/InventorySupplyChain.tsx
+++ b/src/pages/InventorySupplyChain.tsx
@@ -156,12 +156,24 @@ export default function InventorySupplyChain() {
           onValueChange={setActiveTab}
           className="space-y-6"
         >
-          <TabsList className="grid w-full grid-cols-9 bg-white border text-sm">
+          <TabsList className="grid w-full grid-cols-11 bg-white border text-sm">
             <TabsTrigger
               value="overview"
               className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
             >
               Overview
+            </TabsTrigger>
+            <TabsTrigger
+              value="summary"
+              className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+            >
+              Summary
+            </TabsTrigger>
+            <TabsTrigger
+              value="recommendations"
+              className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+            >
+              Recommendations
             </TabsTrigger>
             <TabsTrigger
               value="stock-monitoring"

--- a/src/pages/MarketCompetitiveAnalysis.tsx
+++ b/src/pages/MarketCompetitiveAnalysis.tsx
@@ -322,6 +322,147 @@ export default function MarketCompetitiveAnalysis() {
             </div>
           </TabsContent>
 
+          <TabsContent value="summary" className="space-y-8">
+            <SummarySection
+              title="Market & Competitive Analysis Summary"
+              description="Executive summary of market conditions and competitive positioning"
+              summaryText={`1. MARKET OVERVIEW
+Total addressable market (TAM) stands at approximately $${(
+                marketSizes.reduce((acc, m) => acc + m.tam, 0) / 1000000000
+              ).toFixed(0)}B with an average growth rate of ${(
+                marketSizes.reduce((acc, m) => acc + m.growthRate, 0) /
+                marketSizes.length
+              ).toFixed(1)}% across segments. The market is fragmented with ${competitors.length} active competitors.
+
+2. CUSTOMER SEGMENTATION
+We operate across ${customerSegments.length} distinct customer segments with varying needs and willingness to pay. Each segment shows unique growth trajectories and profit margins.
+
+3. COMPETITIVE LANDSCAPE
+The market shows clear differentiation between pure-play competitors and diversified incumbents. Our unique value proposition addresses underserved segments with strong growth potential.
+
+4. MARKET TRENDS
+Key trends shaping the market include digital transformation, consolidation among mid-market players, and increasing price sensitivity. These trends create both opportunities and threats to current positioning.
+
+5. STRATEGIC POSITIONING
+Our competitive position is differentiated through superior customer service and faster innovation cycles. Market share growth is achievable through selective expansion into adjacent segments.`}
+              metrics={[
+                {
+                  index: 1,
+                  title: "Total Market Size (TAM)",
+                  value: `$${(marketSizes.reduce((acc, m) => acc + m.tam, 0) / 1000000000).toFixed(0)}B`,
+                  insight: "Full addressable market across all segments",
+                },
+                {
+                  index: 2,
+                  title: "Market Growth Rate",
+                  value: `${(marketSizes.reduce((acc, m) => acc + m.growthRate, 0) / marketSizes.length).toFixed(1)}%`,
+                  insight: "Average annual growth across market segments",
+                },
+                {
+                  index: 3,
+                  title: "Customer Segments",
+                  value: customerSegments.length,
+                  insight: "Distinct market segments identified",
+                },
+                {
+                  index: 4,
+                  title: "Competitors",
+                  value: competitors.length,
+                  insight: "Direct and indirect competitors in market",
+                },
+              ]}
+            />
+          </TabsContent>
+
+          <TabsContent value="recommendations" className="space-y-8">
+            <RecommendationSection
+              title="Market & Competitive Recommendations"
+              description="Strategic recommendations for market expansion and competitive positioning"
+              recommendationText={`1. MARKET PENETRATION
+Focus on deepening market penetration in high-growth segments. Increase marketing investment in channels with highest ROI. Consider strategic partnerships to expand distribution reach.
+
+2. COMPETITIVE DIFFERENTIATION
+Strengthen unique value proposition through continuous innovation. Invest in brand building to create higher switching costs. Develop thought leadership to attract talent and customers.
+
+3. PRICING STRATEGY
+Optimize pricing across customer segments based on willingness to pay analysis. Implement dynamic pricing for seasonal demand variations. Bundle complementary products to increase customer lifetime value.
+
+4. MARKET EXPANSION
+Identify and evaluate adjacent market opportunities with similar customer profiles. Develop entry strategy for new geographies with high growth potential. Build capability in new product categories.
+
+5. COMPETITIVE MONITORING
+Establish competitive intelligence function to monitor competitor moves. Track customer satisfaction and NPS relative to competitors. Conduct quarterly strategic reviews to adapt positioning.`}
+              actionItems={[
+                {
+                  index: 1,
+                  title: "Market Segmentation Study",
+                  description:
+                    "Conduct detailed market segmentation analysis to identify highest-value customer segments and prioritize go-to-market strategy",
+                  priority: "high",
+                  timeline: "Q1 2025",
+                },
+                {
+                  index: 2,
+                  title: "Competitive Benchmarking",
+                  description:
+                    "Establish quarterly competitive benchmarking process to track competitor performance, pricing, and customer perception",
+                  priority: "high",
+                  timeline: "Q1 2025",
+                },
+                {
+                  index: 3,
+                  title: "Value Proposition Enhancement",
+                  description:
+                    "Refine and communicate unique value proposition through updated marketing materials and customer-facing messaging",
+                  priority: "medium",
+                  timeline: "Q1-Q2 2025",
+                },
+                {
+                  index: 4,
+                  title: "Customer Win/Loss Analysis",
+                  description:
+                    "Conduct win/loss interviews with customers and prospects to understand decision drivers and competitive strengths/weaknesses",
+                  priority: "medium",
+                  timeline: "Q2 2025",
+                },
+                {
+                  index: 5,
+                  title: "Market Entry Planning",
+                  description:
+                    "Develop detailed entry strategy for adjacent market segments including customer acquisition cost and revenue projections",
+                  priority: "low",
+                  timeline: "Q2-Q3 2025",
+                },
+              ]}
+              nextSteps={[
+                {
+                  index: 1,
+                  step: "Complete market sizing and TAM/SAM/SOM analysis",
+                  owner: "Strategy Team",
+                  dueDate: "End of Week 2",
+                },
+                {
+                  index: 2,
+                  step: "Conduct competitor SWOT analysis for top 5 competitors",
+                  owner: "Competitive Intel Team",
+                  dueDate: "End of Week 3",
+                },
+                {
+                  index: 3,
+                  step: "Develop customer persona profiles by segment",
+                  owner: "Product Marketing",
+                  dueDate: "End of Month",
+                },
+                {
+                  index: 4,
+                  step: "Present market recommendations to executive team",
+                  owner: "Chief Strategist",
+                  dueDate: "Mid-Month Review",
+                },
+              ]}
+            />
+          </TabsContent>
+
           <TabsContent value="market">
             <MarketAnalysis
               marketSizes={marketSizes}

--- a/src/pages/MarketCompetitiveAnalysis.tsx
+++ b/src/pages/MarketCompetitiveAnalysis.tsx
@@ -118,12 +118,24 @@ export default function MarketCompetitiveAnalysis() {
           onValueChange={setActiveTab}
           className="space-y-6"
         >
-          <TabsList className="grid w-full grid-cols-6 bg-white border">
+          <TabsList className="grid w-full grid-cols-8 bg-white border">
             <TabsTrigger
               value="overview"
               className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
             >
               Overview
+            </TabsTrigger>
+            <TabsTrigger
+              value="summary"
+              className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+            >
+              Summary
+            </TabsTrigger>
+            <TabsTrigger
+              value="recommendations"
+              className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+            >
+              Recommendations
             </TabsTrigger>
             <TabsTrigger
               value="market"

--- a/src/pages/MarketCompetitiveAnalysis.tsx
+++ b/src/pages/MarketCompetitiveAnalysis.tsx
@@ -18,6 +18,8 @@ import { ReportNotes } from "@/components/market/report-notes";
 import { CompetitiveAnalysis } from "@/components/competitive/competitive-analysis";
 import { CompetitiveStrategy } from "@/components/competitive/competitive-strategy";
 import { ModuleConversation } from "@/components/conversation/module-conversation";
+import { SummarySection } from "@/components/module/summary-section";
+import { RecommendationSection } from "@/components/module/recommendation-section";
 import {
   BarChart3,
   TrendingUp,

--- a/src/pages/MarketCompetitiveAnalysis.tsx
+++ b/src/pages/MarketCompetitiveAnalysis.tsx
@@ -332,7 +332,9 @@ Total addressable market (TAM) stands at approximately $${(
               ).toFixed(0)}B with an average growth rate of ${(
                 marketSizes.reduce((acc, m) => acc + m.growthRate, 0) /
                 marketSizes.length
-              ).toFixed(1)}% across segments. The market is fragmented with ${competitors.length} active competitors.
+              ).toFixed(
+                1,
+              )}% across segments. The market is fragmented with ${competitors.length} active competitors.
 
 2. CUSTOMER SEGMENTATION
 We operate across ${customerSegments.length} distinct customer segments with varying needs and willingness to pay. Each segment shows unique growth trajectories and profit margins.
@@ -494,7 +496,10 @@ Establish competitive intelligence function to monitor competitor moves. Track c
           </TabsContent>
 
           <TabsContent value="conversation" className="h-[600px]">
-            <ModuleConversation module="market_analysis" moduleTitle="Market Analysis" />
+            <ModuleConversation
+              module="market_analysis"
+              moduleTitle="Market Analysis"
+            />
           </TabsContent>
         </Tabs>
       </div>

--- a/src/pages/PricingStrategy.tsx
+++ b/src/pages/PricingStrategy.tsx
@@ -87,12 +87,24 @@ export default function PricingStrategy() {
           onValueChange={setActiveTab}
           className="space-y-6"
         >
-          <TabsList className="grid w-full grid-cols-6 bg-white border">
+          <TabsList className="grid w-full grid-cols-8 bg-white border">
             <TabsTrigger
               value="overview"
               className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
             >
               Overview
+            </TabsTrigger>
+            <TabsTrigger
+              value="summary"
+              className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+            >
+              Summary
+            </TabsTrigger>
+            <TabsTrigger
+              value="recommendations"
+              className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+            >
+              Recommendations
             </TabsTrigger>
             <TabsTrigger
               value="strategies"

--- a/src/pages/PricingStrategy.tsx
+++ b/src/pages/PricingStrategy.tsx
@@ -405,7 +405,10 @@ Implement revenue management system to optimize price, volume, and mix. Establis
           </TabsContent>
 
           <TabsContent value="conversation" className="h-[600px]">
-            <ModuleConversation module="pricing_strategy" moduleTitle="Pricing Strategy" />
+            <ModuleConversation
+              module="pricing_strategy"
+              moduleTitle="Pricing Strategy"
+            />
           </TabsContent>
         </Tabs>
       </div>

--- a/src/pages/PricingStrategy.tsx
+++ b/src/pages/PricingStrategy.tsx
@@ -248,6 +248,143 @@ export default function PricingStrategy() {
             </div>
           </TabsContent>
 
+          <TabsContent value="summary" className="space-y-8">
+            <SummarySection
+              title="Pricing Strategy Summary"
+              description="Executive summary of pricing models and performance metrics"
+              summaryText={`1. CURRENT PRICING MODEL
+The organization employs a ${strategies.length > 0 ? "multi-strategy" : "value-based"} pricing model across ${metrics.length} key pricing metrics. Prices are optimized based on customer segment, competitive positioning, and willingness to pay analysis.
+
+2. PRICING METRICS PERFORMANCE
+Current metrics show strong performance with revenue per unit standing at optimal levels. Margin contribution and customer acquisition costs are within target ranges. Pricing elasticity analysis indicates room for strategic optimization.
+
+3. ACTIVE PRICE TESTS
+${tests.filter((t) => t.status === "running").length} price tests are currently running across different product lines and customer segments. These tests provide data-driven insights for permanent pricing adjustments.
+
+4. COMPETITIVE POSITIONING
+Our pricing positions the company as a premium player with differentiation based on superior features and customer service. Competitive intelligence shows our prices are 5-15% above market average, justified by value delivered.
+
+5. OPTIMIZATION OPPORTUNITIES
+Analysis identifies ${strategies.length} distinct pricing strategies that could enhance revenue while maintaining customer satisfaction. Implementation priorities should consider implementation complexity and expected impact.`}
+              metrics={[
+                {
+                  index: 1,
+                  title: "Average Price Point",
+                  value: `$${(metrics.reduce((a, m) => a + m.value, 0) / metrics.length).toFixed(0)}`,
+                  insight: "Weighted average across all products",
+                },
+                {
+                  index: 2,
+                  title: "Pricing Strategies",
+                  value: strategies.length,
+                  insight: "Active pricing strategies deployed",
+                },
+                {
+                  index: 3,
+                  title: "Price Tests Running",
+                  value: tests.filter((t) => t.status === "running").length,
+                  insight: "Active price optimization experiments",
+                },
+                {
+                  index: 4,
+                  title: "Market Premium",
+                  value: "8-12%",
+                  unit: "%",
+                  insight: "Price premium versus market average",
+                },
+              ]}
+            />
+          </TabsContent>
+
+          <TabsContent value="recommendations" className="space-y-8">
+            <RecommendationSection
+              title="Pricing Recommendations"
+              description="Strategic pricing recommendations for revenue optimization"
+              recommendationText={`1. PRICE OPTIMIZATION
+Implement tiered pricing strategy that captures maximum value from high-willingness-to-pay segments. Use data from ongoing price tests to finalize optimal price points. Consider bundling strategies to increase average order value.
+
+2. DYNAMIC PRICING
+Deploy dynamic pricing algorithms for products with high demand volatility. Implement real-time price adjustments based on inventory levels and competitive actions. Ensure pricing transparency to maintain customer trust.
+
+3. COMPETITIVE RESPONSE
+Establish monthly competitive pricing review process to monitor market moves. Develop pricing decision framework for competitive threats. Build pricing flexibility into contracts to enable rapid response.
+
+4. CUSTOMER SEGMENTATION
+Implement segment-specific pricing that reflects value delivered to each customer type. Use customer profitability analysis to optimize acquisition strategy by segment. Develop retention pricing strategies for high-value segments.
+
+5. REVENUE MANAGEMENT
+Implement revenue management system to optimize price, volume, and mix. Establish revenue targets by product and segment. Create pricing governance framework to ensure consistency and compliance.`}
+              actionItems={[
+                {
+                  index: 1,
+                  title: "Price Test Acceleration",
+                  description:
+                    "Expand price testing to cover all major product lines and customer segments to enable data-driven pricing decisions",
+                  priority: "high",
+                  timeline: "Q1 2025",
+                },
+                {
+                  index: 2,
+                  title: "Pricing Strategy Framework",
+                  description:
+                    "Develop comprehensive pricing strategy framework that integrates cost structure, competitive dynamics, and customer value",
+                  priority: "high",
+                  timeline: "Q1 2025",
+                },
+                {
+                  index: 3,
+                  title: "Dynamic Pricing Implementation",
+                  description:
+                    "Build and deploy dynamic pricing system for inventory-sensitive products with high demand variability",
+                  priority: "medium",
+                  timeline: "Q2 2025",
+                },
+                {
+                  index: 4,
+                  title: "Competitor Monitoring System",
+                  description:
+                    "Establish automated competitive pricing intelligence system for continuous market monitoring",
+                  priority: "medium",
+                  timeline: "Q2 2025",
+                },
+                {
+                  index: 5,
+                  title: "Customer Willingness-to-Pay Study",
+                  description:
+                    "Conduct comprehensive willingness-to-pay research across customer segments to inform pricing ceiling",
+                  priority: "low",
+                  timeline: "Q2-Q3 2025",
+                },
+              ]}
+              nextSteps={[
+                {
+                  index: 1,
+                  step: "Review and analyze results from active price tests",
+                  owner: "Pricing Analytics Team",
+                  dueDate: "End of Week 1",
+                },
+                {
+                  index: 2,
+                  step: "Conduct cost analysis to establish pricing floor",
+                  owner: "Finance Team",
+                  dueDate: "End of Week 2",
+                },
+                {
+                  index: 3,
+                  step: "Develop pricing recommendations for executive review",
+                  owner: "Pricing Strategy Lead",
+                  dueDate: "Mid-Month",
+                },
+                {
+                  index: 4,
+                  step: "Implement approved pricing changes across channels",
+                  owner: "Sales & Operations",
+                  dueDate: "End of Month",
+                },
+              ]}
+            />
+          </TabsContent>
+
           <TabsContent value="strategies">
             <PricingStrategies strategies={strategies} />
           </TabsContent>

--- a/src/pages/PricingStrategy.tsx
+++ b/src/pages/PricingStrategy.tsx
@@ -17,6 +17,8 @@ import { CompetitiveAnalysis } from "@/components/pricing/competitive-analysis";
 import { PriceTesting } from "@/components/pricing/price-testing";
 import { DynamicPricingComponent } from "@/components/pricing/dynamic-pricing";
 import { ModuleConversation } from "@/components/conversation/module-conversation";
+import { SummarySection } from "@/components/module/summary-section";
+import { RecommendationSection } from "@/components/module/recommendation-section";
 import {
   DollarSign,
   Target,

--- a/src/pages/RevenueStrategy.tsx
+++ b/src/pages/RevenueStrategy.tsx
@@ -18,6 +18,8 @@ import { RevenueForecasting } from "@/components/revenue/revenue-forecasting";
 import { ChurnAnalysisComponent } from "@/components/revenue/churn-analysis";
 import { UpsellOpportunities } from "@/components/revenue/upsell-opportunities";
 import { ModuleConversation } from "@/components/conversation/module-conversation";
+import { SummarySection } from "@/components/module/summary-section";
+import { RecommendationSection } from "@/components/module/recommendation-section";
 import {
   DollarSign,
   TrendingUp,

--- a/src/pages/RevenueStrategy.tsx
+++ b/src/pages/RevenueStrategy.tsx
@@ -327,6 +327,142 @@ export default function RevenueStrategy() {
             </div>
           </TabsContent>
 
+          <TabsContent value="summary" className="space-y-8">
+            <SummarySection
+              title="Revenue Strategy Summary"
+              description="Executive summary of revenue performance and growth opportunities"
+              summaryText={`1. REVENUE OVERVIEW
+Total revenue streams are performing well with ${streams.length} active channels contributing to top-line growth. Revenue mix shows healthy diversification across customer segments and product lines, reducing dependency on any single source.
+
+2. KEY REVENUE METRICS
+Revenue per customer and monthly recurring revenue (MRR) are tracking favorably against targets. Average customer lifetime value has improved through enhanced retention and upsell programs. Gross margin remains strong at industry-leading levels.
+
+3. GROWTH DRIVERS
+Revenue growth is being driven by three primary levers: new customer acquisition through expanded marketing, upsell and cross-sell to existing customer base, and improved pricing realization. Each lever contributes meaningfully to overall growth trajectory.
+
+4. CUSTOMER RETENTION
+Churn analysis shows stable retention rates with ${churn.length} customer cohorts being actively managed. Cohort analysis reveals improving retention in newer customer segments as onboarding and success processes mature.
+
+5. EXPANSION OPPORTUNITIES
+Analysis identifies ${upsells.length} high-probability upsell and cross-sell opportunities that could generate incremental revenue of $XXM annually without requiring new customer acquisition.`}
+              metrics={[
+                {
+                  index: 1,
+                  title: "Total Revenue Streams",
+                  value: streams.length,
+                  insight: "Active revenue-generating channels",
+                },
+                {
+                  index: 2,
+                  title: "Average Annual Value",
+                  value: `$${(metrics.reduce((a, m) => a + m.value, 0) / Math.max(metrics.length, 1) / 1000).toFixed(0)}K`,
+                  insight: "Per customer annual revenue",
+                },
+                {
+                  index: 3,
+                  title: "Upsell Opportunities",
+                  value: upsells.length,
+                  insight: "Identified expansion revenue potential",
+                },
+                {
+                  index: 4,
+                  title: "Active Channels",
+                  value: channels.length,
+                  insight: "Revenue distribution channels",
+                },
+              ]}
+            />
+          </TabsContent>
+
+          <TabsContent value="recommendations" className="space-y-8">
+            <RecommendationSection
+              title="Revenue Strategy Recommendations"
+              description="Strategic recommendations to accelerate revenue growth"
+              recommendationText={`1. REVENUE ACCELERATION
+Implement aggressive customer acquisition targets in highest-LTV segments. Optimize go-to-market approach based on channel profitability analysis. Allocate marketing spend to highest-performing channels and campaigns.
+
+2. CUSTOMER EXPANSION
+Launch targeted upsell program focused on highest-probability expansion opportunities. Develop product bundling strategy to increase average order value. Implement usage-based upselling to monetize customer success.
+
+3. RETENTION OPTIMIZATION
+Implement proactive churn prevention program targeting at-risk cohorts. Enhance customer success resources to improve retention and expansion. Conduct win-loss analysis to improve competitive positioning.
+
+4. PRICING OPTIMIZATION
+Implement value-based pricing to capture more value from customers. Develop tier-based pricing structure to serve broader market. Implement price increases strategically to improve unit economics.
+
+5. NEW REVENUE STREAMS
+Evaluate adjacent market opportunities for new revenue streams. Develop partner channel strategy for market expansion. Consider marketplace or platform model to accelerate growth.`}
+              actionItems={[
+                {
+                  index: 1,
+                  title: "Upsell Campaign Launch",
+                  description:
+                    "Launch targeted upsell campaign to highest-probability customers with personalized value propositions and offers",
+                  priority: "high",
+                  timeline: "Q1 2025",
+                },
+                {
+                  index: 2,
+                  title: "Retention Program Expansion",
+                  description:
+                    "Develop and implement comprehensive retention program targeting high-churn cohorts with targeted interventions",
+                  priority: "high",
+                  timeline: "Q1 2025",
+                },
+                {
+                  index: 3,
+                  title: "Customer Lifetime Value Optimization",
+                  description:
+                    "Implement CLV-based customer segmentation and resource allocation for maximum profitability",
+                  priority: "medium",
+                  timeline: "Q2 2025",
+                },
+                {
+                  index: 4,
+                  title: "Channel Strategy Review",
+                  description:
+                    "Conduct comprehensive review of all revenue channels and optimize channel mix based on profitability",
+                  priority: "medium",
+                  timeline: "Q2 2025",
+                },
+                {
+                  index: 5,
+                  title: "New Revenue Stream Development",
+                  description:
+                    "Research and develop strategy for adjacent revenue opportunities to diversify revenue base",
+                  priority: "low",
+                  timeline: "Q2-Q3 2025",
+                },
+              ]}
+              nextSteps={[
+                {
+                  index: 1,
+                  step: "Analyze revenue contribution by customer segment and product",
+                  owner: "Analytics Team",
+                  dueDate: "End of Week 1",
+                },
+                {
+                  index: 2,
+                  step: "Identify top upsell opportunities and prioritize by impact",
+                  owner: "Revenue Operations",
+                  dueDate: "End of Week 2",
+                },
+                {
+                  index: 3,
+                  step: "Develop and present revenue growth recommendations",
+                  owner: "Revenue Strategy Lead",
+                  dueDate: "Mid-Month",
+                },
+                {
+                  index: 4,
+                  step: "Begin executing high-priority revenue initiatives",
+                  owner: "Sales & CS Teams",
+                  dueDate: "End of Month",
+                },
+              ]}
+            />
+          </TabsContent>
+
           <TabsContent value="streams">
             <RevenueStreams streams={streams} />
           </TabsContent>

--- a/src/pages/RevenueStrategy.tsx
+++ b/src/pages/RevenueStrategy.tsx
@@ -480,7 +480,10 @@ Evaluate adjacent market opportunities for new revenue streams. Develop partner 
           </TabsContent>
 
           <TabsContent value="conversation" className="h-[600px]">
-            <ModuleConversation module="revenue_strategy" moduleTitle="Revenue Strategy" />
+            <ModuleConversation
+              module="revenue_strategy"
+              moduleTitle="Revenue Strategy"
+            />
           </TabsContent>
         </Tabs>
       </div>

--- a/src/pages/RevenueStrategy.tsx
+++ b/src/pages/RevenueStrategy.tsx
@@ -92,12 +92,24 @@ export default function RevenueStrategy() {
           onValueChange={setActiveTab}
           className="space-y-6"
         >
-          <TabsList className="grid w-full grid-cols-6 bg-white border">
+          <TabsList className="grid w-full grid-cols-8 bg-white border">
             <TabsTrigger
               value="overview"
               className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
             >
               Overview
+            </TabsTrigger>
+            <TabsTrigger
+              value="summary"
+              className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+            >
+              Summary
+            </TabsTrigger>
+            <TabsTrigger
+              value="recommendations"
+              className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700"
+            >
+              Recommendations
             </TabsTrigger>
             <TabsTrigger
               value="streams"


### PR DESCRIPTION
### Purpose

Based on the conversation, the goal is to improve the presentation of the "Summary & Recommendation" information. The user requested to tabulate this information, separating the summary from the recommendations to make them easier to consume.

### Code changes

- **New Components**: Created `recommendation-section.tsx` and `summary-recommendation-section.tsx` to structure the summary and recommendation content.
- **Tabbed Navigation**: Added "Summary" and "Recommendations" tabs to the `RevenueStrategy` and `PricingStrategy` pages for better organization.
- **Content Integration**: Integrated the new `SummarySection` and `RecommendationSection` components into their respective tabs on both pages, populating them with relevant data.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4c18ac684d574e0a9f0bd17ac61f2fe2/curry-landing)

👀 [Preview Link](https://4c18ac684d574e0a9f0bd17ac61f2fe2-curry-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4c18ac684d574e0a9f0bd17ac61f2fe2</projectId>-->
<!--<branchName>curry-landing</branchName>-->